### PR TITLE
Feat: Dynamic Component Support

### DIFF
--- a/gui/components/dialog_panel.py
+++ b/gui/components/dialog_panel.py
@@ -2,7 +2,7 @@ from PyQt5.QtCore import QUrl
 from qfluentwidgets import MessageBoxBase, SubtitleLabel, LineEdit
 
 
-class SaveSettingMessageBox(MessageBoxBase):
+class CreateSettingMessageBox(MessageBoxBase):
     """ Custom message box """
 
     def __init__(self, parent=None):

--- a/gui/components/expand/expandTemplate.py
+++ b/gui/components/expand/expandTemplate.py
@@ -23,6 +23,7 @@ class ConfigItem:
         self.key = kwargs.get('key')
         self.selection = kwargs.get('selection')
         self.type = kwargs.get('type')
+        self.readOnly = kwargs.get('readOnly', False)
 
 
 def parsePatch(func, key: str, raw_sig: str) -> None:
@@ -84,6 +85,7 @@ class TemplateLayout(QWidget):
                 currentKey = cfg.key
                 inputComponent = LineEdit(self)
                 inputComponent.setText(str(self.config.get(currentKey)))
+                inputComponent.setReadOnly(cfg.readOnly)
                 self.patch_signal.connect(partial(parsePatch, inputComponent.setText, currentKey))
                 confirmButton = PushButton(self.tr('确定'), self)
                 confirmButton.clicked.connect(partial(self._commit, currentKey, inputComponent, labelComponent))

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -55,9 +55,10 @@ class HomeFragment(QFrame):
         self.info_box.setFixedHeight(45)
         self.infoLayout = QHBoxLayout(self.info_box)
 
-        title = self.tr("蔚蓝档案自动脚本") + f' {self.config.get("name")}'
+        title = self.tr("蔚蓝档案自动脚本") + ' {name}'
         self.banner_visible = self.config.get('bannerVisibility')
-        self.label = SubtitleLabel(title, self)
+        self.label = SubtitleLabel(self)
+        config.inject(self.label, title)
         self.info = SubtitleLabel(self.tr('无任务'), self)
         setFont(self.label, 24)
         setFont(self.info, 24)

--- a/gui/fragments/settings.py
+++ b/gui/fragments/settings.py
@@ -19,7 +19,8 @@ class SettingsFragment(ScrollArea):
         self.config = config
         self.scrollWidget = QWidget()
         self.expandLayout = ExpandLayout(self.scrollWidget)
-        self.settingLabel = TitleLabel(self.tr(f"普通设置") + f' {self.config["name"]}', self.scrollWidget)
+        self.settingLabel = TitleLabel( self.scrollWidget)
+        config.inject(self.settingLabel, self.tr(f"普通设置") + " {name}")
 
         self.basicGroup = SettingCardGroup(
             self.tr("基本"), self.scrollWidget)

--- a/gui/fragments/switch.py
+++ b/gui/fragments/switch.py
@@ -25,7 +25,8 @@ class SwitchFragment(ScrollArea):
         # 创建一个ExpandLayout实例作为滚动区域的布局管理器
         self.expandLayout = ExpandLayout(self.scrollWidget)
         # 创建一个标题为“调度设置”的TitleLabel实例
-        self.settingLabel = TitleLabel(self.tr(f"配置设置") + f" {self.config['name']}", self.scrollWidget)
+        self.settingLabel = TitleLabel(self.scrollWidget)
+        config.inject(self.settingLabel, self.tr("配置设置") + " {name}")
         # 初始化basicGroup变量,_setting_cards列表
         self.basicGroup = None
         self._setting_cards = []

--- a/gui/util/config_set.py
+++ b/gui/util/config_set.py
@@ -1,13 +1,57 @@
 import json
-from core.notification import notify
+import re
+
+from PyQt5.QtCore import QObject
+
 from gui.util.translator import baasTranslator as bt
+
+
+class BoundComponent(QObject):
+    """
+    BoundComponent is a class that binds a component to a string rule. The string rule is a string that contains
+    placeholders that are keys in the config. When the config is updated, the component will be updated with the new
+    value. The rule string is a definition of how the component should be updated. For example, if the rule is
+    "Title: {title} - Subtitle: {subtitle}", the component will be updated with the new value of the title and subtitle
+    keys in the config.
+
+    :param component: Component to bind
+    :param string_rule: String rule to bind
+    :param config_manager: Config manager
+    :param attribute: Attribute to bind (default is setText)
+    """
+    def __init__(self, component,  string_rule, config_manager, attribute="setText"):
+        super().__init__()
+        self.component = component
+        self.attribute = attribute
+        self.string_rule = string_rule
+        self.config_manager = config_manager
+
+        self.update_component()  # 初始化时更新组件
+
+    def update_component(self):
+        """ Update the component with the new value """
+        # Replace the keys in the rule with the values in the config
+        new_value = self.string_rule
+        keys_in_rule = re.findall(r'{(.*?)}', self.string_rule)
+        for key in keys_in_rule:
+            new_value = new_value.replace(f'{{{key}}}', self.config_manager.config.get(key, ''))
+
+        # Dynamic call the attribute function of the component
+        getattr(self.component, self.attribute)(new_value)
+
+    def config_updated(self, key):
+        if f'{{{key}}}' in self.string_rule:
+            self.update_component()
 
 
 class ConfigSet:
     def __init__(self, config_dir):
+        super().__init__()
         print(config_dir)
         self.config = None
         self.server_mode = 'CN'
+        self.inject_comp_list = []
+        self.inject_config_list = []
         self.main_thread = None
         self.static_config = None
         self.config_dir = config_dir
@@ -41,6 +85,12 @@ class ConfigSet:
         self.config[key] = value
         with open(f'./config/{self.config_dir}/config.json', 'w', encoding='utf-8') as f:
             json.dump(self.config, f, indent=4, ensure_ascii=False)
+        self.dynamic_update(key)
+
+    def dynamic_update(self, key):
+        if key not in self.inject_config_list: return
+        for comp in self.inject_comp_list:
+            comp.config_updated(key)
 
     def update(self, key, value):
         self.set(key, value)
@@ -64,3 +114,16 @@ class ConfigSet:
 
     def get_main_thread(self):
         return self.main_thread
+
+    def inject(self, component, string_rule, attribute="setText"):
+        """
+        Inject a component with a string rule
+        :param component: Component to inject
+        :param string_rule: String rule
+        :param attribute: Attribute to inject (default is setText)
+        :return: BoundComponent, which can be ignored
+        """
+        bounded = BoundComponent(component, string_rule, self, attribute)
+        self.inject_config_list.extend(re.findall(r'{(.*?)}', string_rule))
+        self.inject_comp_list.append(bounded)
+        return bounded

--- a/window.py
+++ b/window.py
@@ -6,19 +6,20 @@ import shutil
 import sys
 import threading
 from functools import partial
+from typing import Union
 
-from PyQt5.QtCore import Qt, QLocale, QSize, QTranslator, QPoint, pyqtSignal
+from PyQt5.QtCore import Qt, QSize, QPoint, pyqtSignal, QObject
 from PyQt5.QtGui import QIcon, QColor
-from PyQt5.QtWidgets import QApplication, QHBoxLayout
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel
 from qfluentwidgets import FluentIcon as FIF, FluentTranslator, SplashScreen, MSFluentWindow, TabBar, \
-    MSFluentTitleBar, MessageBox, InfoBar, InfoBarIcon, InfoBarPosition, TransparentToolButton
+    MSFluentTitleBar, MessageBox, TransparentToolButton, FluentIconBase, TabItem, \
+    RoundMenu, Action, MenuAnimationType, MessageBoxBase, LineEdit
 from qfluentwidgets import (SubtitleLabel, setFont, setThemeColor)
 
 from core import default_config
-from gui.components.dialog_panel import SaveSettingMessageBox
+from gui.components.dialog_panel import CreateSettingMessageBox
 from gui.fragments.process import ProcessFragment
 from gui.fragments.readme import ReadMeWindow
-
 from gui.util import notification
 from gui.util.config_set import ConfigSet
 from gui.util.translator import baasTranslator as bt
@@ -30,6 +31,7 @@ sys.path.append('./')
 # Offer the error to the error.log
 ICON_DIR = 'gui/assets/logo.png'
 LAST_NOTICE_TIME = 0
+
 
 def update_config_reserve_old(config_old, config_new):  # 保留旧配置原有的键，添加新配置中没有的，删除新配置中没有的键
     for key in config_new:
@@ -185,6 +187,114 @@ class Widget(MSFluentWindow):
         self.setObjectName(text.replace(' ', '-'))
 
 
+class RenameDialogBox(MessageBoxBase):
+    def __init__(self, parent=None, config=None):
+        super().__init__(parent)
+        RenameDialogContext = QObject()
+        self.titleLabel = SubtitleLabel(self.tr('配置详情'), self)
+        self.viewLayout.addWidget(self.titleLabel)
+
+        self.name_input = None
+
+        configItems = [
+            {
+                'label': RenameDialogContext.tr('原来的配置名称'),
+                'key': 'name',
+                'type': 'text',
+                'readOnly': True,
+            },
+            {
+                'label': RenameDialogContext.tr('修改后的配置名称'),
+                'key': 'name',
+                'type': 'text',
+                'readOnly': False,
+            }
+        ]
+
+        for ind, cfg in enumerate(configItems):
+            optionPanel = QHBoxLayout(self)
+            labelComponent = QLabel(bt.tr('ConfigTranslation', cfg['label']), self)
+            optionPanel.addWidget(labelComponent, 0, Qt.AlignLeft)
+            optionPanel.addStretch(1)
+            currentKey = cfg['key']
+            inputComponent = LineEdit(self)
+            if ind == 1: self.name_input = inputComponent
+            if cfg['readOnly']: inputComponent.setReadOnly(True)
+            inputComponent.setText(config.get(currentKey))
+            optionPanel.addWidget(inputComponent, 0, Qt.AlignRight)
+            self.viewLayout.addLayout(optionPanel)
+            labelComponent.setStyleSheet("""
+                font-family: "Microsoft YaHei";
+                font-size: 15px;
+            """)
+        self.yesButton.setText(RenameDialogContext.tr('确定'))
+        self.cancelButton.setText(RenameDialogContext.tr('取消'))
+        self.widget.setMinimumWidth(350)
+
+
+class BAASTabItem(TabItem):
+    def __init__(self, *args, **kwargs):
+        if 'config' in kwargs.keys():
+            self.config = kwargs.pop('config')
+        if 'window' in kwargs.keys():
+            self.window = kwargs.pop('window')
+        super().__init__(*args, **kwargs)
+
+    def contextMenuEvent(self, a0):
+        print(self.config.get('name'))
+        menu = RoundMenu(parent=self)
+        rename_action = Action(FIF.EDIT, self.tr('重命名'), triggered=self._showRenameDialog)
+        menu.addAction(rename_action)
+        rename_action.setCheckable(True)
+        rename_action.setChecked(True)
+        menu.exec(a0.globalPos(), aniType=MenuAnimationType.DROP_DOWN)
+
+    def _showRenameDialog(self):
+        rename_dialog = RenameDialogBox(self.window, self.config)
+        if not rename_dialog.exec_(): return
+        new_name = rename_dialog.name_input.text()
+        if new_name == self.config.get('name'): return
+        self.config.set('name', new_name)
+        self.setText(new_name)
+
+
+class BAASTabBar(TabBar):
+    def __init__(self, parent):
+        super().__init__(parent)
+
+    def addBAASTab(self, routeKey: str, config: ConfigSet, icon: Union[QIcon, str, FluentIconBase] = None, window=None):
+        return self.insertBAASTab(-1, routeKey, config, icon, window=window)
+
+    def insertBAASTab(self, index: int, routeKey: str, config: ConfigSet,
+                      icon: Union[QIcon, str, FluentIconBase] = None, window=None, onClick=None):
+        if routeKey in self.itemMap:
+            raise ValueError(f"The route key `{routeKey}` is duplicated.")
+        if index == -1:
+            index = len(self.items)
+        if index <= self.currentIndex() and self.currentIndex() >= 0:
+            self._currentIndex += 1
+        text = config.get_origin('name')
+        item = BAASTabItem(text, self.view, icon, config=config, window=window)
+        item.setRouteKey(routeKey)
+        _w = self.tabMaximumWidth() if self.isScrollable() else self.tabMinimumWidth()
+        item.setMinimumWidth(_w)
+        item.setMaximumWidth(self.tabMaximumWidth())
+        item.setShadowEnabled(self.isTabShadowEnabled())
+        item.setCloseButtonDisplayMode(self.closeButtonDisplayMode)
+        item.setSelectedBackgroundColor(
+            self.lightSelectedBackgroundColor, self.darkSelectedBackgroundColor)
+        item.pressed.connect(self._onItemPressed)
+        item.closed.connect(lambda: self.tabCloseRequested.emit(self.items.index(item)))
+        if onClick:
+            item.pressed.connect(onClick)
+        self.itemLayout.insertWidget(index, item, 1)
+        self.items.insert(index, item)
+        self.itemMap[routeKey] = item
+        if len(self.items) == 1:
+            self.setCurrentIndex(0)
+        return item
+
+
 class BAASTitleBar(MSFluentTitleBar):
     """ Title bar with icon and title """
     onHelpButtonClicked = pyqtSignal()
@@ -198,7 +308,7 @@ class BAASTitleBar(MSFluentTitleBar):
         self.hBoxLayout.insertLayout(4, self.toolButtonLayout)
 
         # add tab bar
-        self.tabBar = TabBar(self)
+        self.tabBar = BAASTabBar(self)
         self.tabBar.setMovable(False)
         self.tabBar.setTabMaximumWidth(120)
         self.tabBar.setTabShadowEnabled(False)
@@ -318,7 +428,7 @@ class Window(MSFluentWindow):
 
         # Add some tabs in the group
         for home_tab in self._sub_list[0]:
-            self.addTab(home_tab.object_name, home_tab.config['name'], None)
+            self.addTab(home_tab.object_name, home_tab.config, None)
         # self.stackedWidget.currentChanged.connect(self.onTabChanged)
         self.tabBar.currentChanged.connect(self.onTabChanged)
         self.tabBar.tabAddRequested.connect(self.onTabAddRequested)
@@ -378,7 +488,7 @@ class Window(MSFluentWindow):
         self.stackedWidget.setCurrentWidget(self._sub_list[i0][i1], popOut=False)
 
     def onTabAddRequested(self):
-        addDialog = SaveSettingMessageBox(self)
+        addDialog = CreateSettingMessageBox(self)
         addDialog.pathLineEdit.setFocus()
         if addDialog.exec_():
             text = addDialog.pathLineEdit.text()
@@ -407,18 +517,18 @@ class Window(MSFluentWindow):
             for i in range(0, len(_sub_list_)):
                 self._sub_list[i].append(_sub_list_[i])
                 self.stackedWidget.addWidget(_sub_list_[i])
-            self.addTab(_sub_list_[0].object_name, text, 'resource/Smiling_with_heart.png')
+            self.addTab(_sub_list_[0].object_name, _config, 'resource/Smiling_with_heart.png')
 
     def onTabCloseRequested(self, i0):
         config_name = self._sub_list[0][i0].config["name"]
-        title = self.tr('是否要删除配置：') +  f' {config_name}？'
+        title = self.tr('是否要删除配置：') + f' {config_name}？'
         content = self.tr("""你需要在确认后重启BAAS以完成更改。""")
         closeRequestBox = MessageBox(title, content, self)
         if closeRequestBox.exec():
             shutil.rmtree(f'./config/{self._sub_list[0][i0].config.config_dir}')
 
-    def addTab(self, routeKey, text, icon):
-        self.tabBar.addTab(routeKey, text, icon)
+    def addTab(self, routeKey: str, config: ConfigSet, icon: Union[QIcon, str, FluentIconBase, None]):
+        self.tabBar.addBAASTab(routeKey, config, icon, window=self)
 
     def dispatchWindow(self):
         self.setWindowIcon(QIcon(ICON_DIR))


### PR DESCRIPTION
新增可以右键重命名配置

**并且支持动态组件**

意思是修改了config之后，对于使用到该config进行显示的组件，能够进行动态更新。

用法实例：

```python
# 规则字符串，其中注意的是配置的key需要用"{}"进行包裹
ruleStr = "普通的字符串{CONFIG_KEY}"
# 显示文字的组件 
comp = QLabel(parent)

# 该方法返回值可以忽略。
# 下面这个config是ConfigSet类的对象
# attribute是设置该组件字符串的方法，默认为setText
config.inject(comp, ruleStr, attribute="setText")

# 只需要这一句就OK了
```
