### PR TITLE
feat: support averaging AP usage across multiple activity stages when sweep count is -1

### DIFF
--- a/module/activities/activity_utils.py
+++ b/module/activities/activity_utils.py
@@ -95,6 +95,8 @@ def activity_sweep(self):
     self.stage_data = get_stage_data(self)
     sweep_one_time_ap = self.stage_data["sweep_ap_cost_mission"]
     total_mission = len(self.stage_data["mission"])
+    if len(times) == 1 and times[0] == -1:
+        times = [int(ap / sum(sweep_one_time_ap[num] for num in number))] * len(number)
     for i in range(0, min(len(number), len(times))):
         sweep_times = times[i]
         if type(sweep_times) is float:


### PR DESCRIPTION
当活动关卡扫荡次数设置为-1时，将可用体力平均分配至所选的多个关卡，并尽可能用尽所有体力。
此前，扫荡次数设置为大于等于 50 时，仅支持对单一关卡进行体力清空，无法在多个关卡之间平均消耗体力。

本地测试结果：
<img width="371" alt="image" src="https://github.com/user-attachments/assets/dace8a53-5ef3-4440-a13e-806162b44612" />
<img width="645" alt="image" src="https://github.com/user-attachments/assets/2da9df6c-e41c-4249-8c4e-5fff4775925c" />
<img width="767" alt="image" src="https://github.com/user-attachments/assets/904ad4bb-9518-4c30-b28f-f1d84d15a252" />