### PR TITLE
fix: change the data type of explore_normal/hard_task_list to str

### DIFF
--- a/core/config/default_config.py
+++ b/core/config/default_config.py
@@ -403,8 +403,8 @@ DEFAULT_CONFIG = """
         ["primary","normal","advanced","superior"]
     ],
     "purchase_lesson_ticket_times": "0",
-    "explore_normal_task_list": [],
-    "explore_hard_task_list": [],
+    "explore_normal_task_list": "",
+    "explore_hard_task_list": "",
     "emulatorIsMultiInstance": false,
     "emulatorMultiInstanceNumber": 0,
     "multiEmulatorName": "mumu",

--- a/core/config/generated_user_config.py
+++ b/core/config/generated_user_config.py
@@ -70,8 +70,8 @@ class Config:
     lesson_relationship_first: bool
     lesson_each_region_object_priority: list
     purchase_lesson_ticket_times: str
-    explore_normal_task_list: list
-    explore_hard_task_list: list
+    explore_normal_task_list: str
+    explore_hard_task_list: str
     emulatorIsMultiInstance: bool
     emulatorMultiInstanceNumber: int
     multiEmulatorName: str


### PR DESCRIPTION
修复数据类型，保持和用户文档及开发文档中一致为str而非list，否则直接在配置list中填入关卡，自动推图时会解析失败
<img width="806" alt="image" src="https://github.com/user-attachments/assets/9c8adf16-c7ac-47e5-a72e-9105ac0754aa" />
<img width="1571" alt="image" src="https://github.com/user-attachments/assets/1f560a56-00a3-47dc-b181-4fc1aa3ce62c" />
