### PR TITLE
fix(type-hint): fix invalid type hint

### DIFF
--- a/core/color.py
+++ b/core/color.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import time
 import typing
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from core import Baas_thread
+if TYPE_CHECKING:
+    from core.Baas_thread import Baas_thread
 
 
 def wait_loading(self: Baas_thread) -> None:
@@ -133,8 +137,10 @@ def calcTotalRGBDiff(rgb1, rgb2):
 def calcTotalRGBMeanABSDiff(img1, img2):
     return np.abs(img1 - img2).mean()
 
+
 def create_rgb_feature(self, name, pos_list, rgb_list):
     self.rgb_feature[name] = [pos_list, rgb_list]
+
 
 def remove_rgb_feature(self, name):
     if name in self.rgb_feature:

--- a/core/picture.py
+++ b/core/picture.py
@@ -1,30 +1,34 @@
+from __future__ import annotations
+
 import time
 import typing
+from typing import TYPE_CHECKING
 
-import cv2
-
-from core import color, image, Baas_thread
+from core import color, image
 from core.color import match_rgb_feature
 from core.exception import RequestHumanTakeOver, FunctionCallTimeout, PackageIncorrect
 from module.main_story import set_acc_and_auto
 
+if TYPE_CHECKING:
+    from core.Baas_thread import Baas_thread
+
 
 def co_detect(
-            self: Baas_thread,
-            rgb_ends: typing.Union[list[str], str] = None,
-            rgb_reactions: dict = None,
-            img_ends: typing.Union[list, str, tuple] = None,
-            img_reactions: dict = None,
-            skip_first_screenshot=False,
-            tentative_click=False,
-            tentative_x=1238,
-            tentative_y=45,
-            max_fail_cnt=10,
-            pop_ups_rgb_reactions: dict = None,
-            pop_ups_img_reactions: dict = None,
-            time_out=600,
-            check_pkg_interval=20
-    ):
+    self: Baas_thread,
+    rgb_ends: typing.Union[list[str], str] = None,
+    rgb_reactions: dict = None,
+    img_ends: typing.Union[list, str, tuple] = None,
+    img_reactions: dict = None,
+    skip_first_screenshot=False,
+    tentative_click=False,
+    tentative_x=1238,
+    tentative_y=45,
+    max_fail_cnt=10,
+    pop_ups_rgb_reactions: dict = None,
+    pop_ups_img_reactions: dict = None,
+    time_out=600,
+    check_pkg_interval=20
+):
     """
         Detects specific RGB or image features on the screen and performs actions based on the detection.
 
@@ -233,10 +237,10 @@ def choose_buff(self):
 
 
 def match_img_feature(
-        self: Baas_thread,
-        img_feature: typing.Union[tuple, str],
-        threshold: float = 0.8,
-        rgb_diff: int = 20
+    self: Baas_thread,
+    img_feature: typing.Union[tuple, str],
+    threshold: float = 0.8,
+    rgb_diff: int = 20
 ) -> bool:
     if type(img_feature) is tuple:
         image_name = img_feature[0]
@@ -248,7 +252,6 @@ def match_img_feature(
     else:
         image_name = img_feature
     return image.compare_image(self, image_name, threshold, rgb_diff)
-
 
 
 def match_any_img_feature(self: Baas_thread, featureList: list[typing.Union[tuple, str]]) -> bool:

--- a/module/ExploreTasks/TaskUtils.py
+++ b/module/ExploreTasks/TaskUtils.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import json
 import time
+from typing import TYPE_CHECKING
 
-from core import image, picture, Baas_thread, color
+from core import image, picture, color
 from core.image import swipe_search_target_str
 from module import main_story
+
+if TYPE_CHECKING:
+    from core.Baas_thread import Baas_thread
 
 
 # Functions related to navigation or obtaining map data
@@ -137,7 +143,7 @@ def get_challenge_state(self, challenge_count=1) -> list[int]:
     # to challenge menu
     img_ends = 'normal_task_challenge-menu'
     img_possibles = {
-        "normal_task_challenge-button": (536,302),
+        "normal_task_challenge-button": (536, 302),
         "activity_quest-challenge-button": (319, 270)
     }
     picture.co_detect(self, None, None, img_ends, img_possibles, True)

--- a/module/ExploreTasks/explore_task.py
+++ b/module/ExploreTasks/explore_task.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from core import color, image, picture
 from module import main_story
 from module.ExploreTasks.TaskUtils import to_mission_info, execute_grid_task, get_challenge_state, \
     employ_units, get_stage_data, convert_team_config, to_region, to_hard_event, to_normal_event
 
+if TYPE_CHECKING:
+    from core.Baas_thread import Baas_thread
 
-def validate_and_add_task(self, task: str, tasklist: list[tuple[int, int, dict]],
+
+def validate_and_add_task(self: Baas_thread, task: str, tasklist: list[tuple[int, int, dict]],
                           isNormal: bool) -> tuple[bool, str]:
     """
     Verifies the task information and returns the results.
@@ -63,7 +70,7 @@ def validate_and_add_task(self, task: str, tasklist: list[tuple[int, int, dict]]
     return True, ""
 
 
-def need_fight(self, taskDataName: str, isNormal: bool):
+def need_fight(self: Baas_thread, taskDataName: str, isNormal: bool):
     """
     Determines if a fight is needed based on the given task parameters.
 
@@ -104,7 +111,7 @@ def need_fight(self, taskDataName: str, isNormal: bool):
     return False
 
 
-def set_explore_task_mode(self):
+def set_explore_task_mode(self: Baas_thread):
     st = "simple" if self.config.explore_task_use_simple_mode else "grid"
     self.logger.info("Set Explore Task Mode : [ " + st + " ]")
 
@@ -118,8 +125,7 @@ def set_explore_task_mode(self):
     picture.co_detect(self, rgb_ends, rgb_possibles, skip_first_screenshot=True)
 
 
-
-def explore_normal_task(self):
+def explore_normal_task(self: Baas_thread):
     """
         Implement the logic for exploring normal tasks.
     """
@@ -236,13 +242,15 @@ def explore_normal_task(self):
             to_normal_event(self, True)
     return True
 
+
 # We only need the first team for simple mode
 def extract_first_team(taskData):
     for attribute, _ in taskData["start"]:
         if attribute in ["burst", "pierce", "mystic", "shock"]:
             return {"start": [[attribute, [0, 0]]]}
 
-def explore_hard_task(self):
+
+def explore_hard_task(self: Baas_thread):
     """
     Implement the logic for exploring hard tasks.
     """

--- a/module/ExploreTasks/sweep_task.py
+++ b/module/ExploreTasks/sweep_task.py
@@ -1,9 +1,15 @@
-from copy import deepcopy
+from __future__ import annotations
 
-from core import picture, Baas_thread, image
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+from core import picture, image
 from core.color import check_sweep_availability
 from core.config.config_set import ConfigSet
 from module.ExploreTasks.TaskUtils import to_hard_event, to_mission_info, to_region, to_normal_event
+
+if TYPE_CHECKING:
+    from core.Baas_thread import Baas_thread
 
 
 def print_task_list(self: Baas_thread, tasklist: list[list], title: str, isNormal: bool) -> None:
@@ -73,7 +79,7 @@ def sweep_hard_task(self: Baas_thread):
     return True
 
 
-def sweep_normal_task(self):
+def sweep_normal_task(self: Baas_thread):
     self.to_main_page(skip_first_screenshot=True)
     current_ap = self.get_ap(True)
     tasklist = deepcopy(self.config.unfinished_normal_tasks)


### PR DESCRIPTION
Fixed invalid type hint for Baas_thread class.
Added TYPE_CHECKING to avoid circular import at runtime.

修复了错误的type hint
对于Python 3.14之前的版本，添加  `from __future__ import annotations` 来lazy化类型检查（在Python 3.14 及之后, type checking 将默认lazy）
同时使用 `TYPE_CHECKING` 避免 circular import
实现了对于self的正常类型检查
