### PR TITLE
feat(window): Log full exception traceback

### DIFF
--- a/window.py
+++ b/window.py
@@ -463,7 +463,8 @@ class Window(MSFluentWindow):
                 self._sub_list[0][i].main_thread_attach.Main = self.main_class
         except Exception as e:
             from core.utils import Logger
-            Logger(self._sub_list[0][0].main_thread_attach.logger_signal).error(e.__str__())
+            import traceback
+            Logger(self._sub_list[0][0].main_thread_attach.logger_signal).error(traceback.format_exc())
 
     def call_update(self):
         self.schedulerInterface.update_settings()


### PR DESCRIPTION
window 在运行 Main() 出错时 仅打印e.__str__() 这对于后续bug诊断是极其不友好的；
改为打印完整 traceback 有利于用户反馈和开发者诊断信息；例如：
<img width="1101" height="425" alt="image" src="https://github.com/user-attachments/assets/05289df3-1c0d-4863-9942-f1f2aaf8ac24" />
