### PR TITLE
Fix: Emit and store adbIP when port is changed

### DIFF
--- a/gui/components/expand/serverConfig.py
+++ b/gui/components/expand/serverConfig.py
@@ -87,15 +87,20 @@ class Layout(TemplateLayout):
         if addr.find(':') != -1:
             ip = x.text().split(':')[0]
             port = x.text().split(':')[1]
-            port_sig_str = json.dumps({
-                "name": "adbPort",
-                "value": port
-            })
-            self.patch_signal.emit(port_sig_str)
-            ip_sig_str = json.dumps({
-                "name": "adbIP",
-                "value": ip
-            })
-            self.patch_signal.emit(ip_sig_str)
-            self.config.set('adbIP', ip)
-            self.config.set('adbPort', port)
+        # serial like emulator-xxxx  or  usb device
+        else:
+            ip = ""
+            port = addr
+
+        port_sig_str = json.dumps({
+            "name": "adbPort",
+            "value": port
+        })
+        self.patch_signal.emit(port_sig_str)
+        ip_sig_str = json.dumps({
+            "name": "adbIP",
+            "value": ip
+        })
+        self.patch_signal.emit(ip_sig_str)
+        self.config.set('adbIP', ip)
+        self.config.set('adbPort', port)


### PR DESCRIPTION
Added logic to emit a patch signal for adbIP and store it in the config when the port field contains an IP:port value. This ensures both adbIP and adbPort are updated and signaled together.