### PR TITLE
update: Global actitivy

### DIFF
--- a/core/config/default_config.py
+++ b/core/config/default_config.py
@@ -3543,7 +3543,7 @@ STATIC_DEFAULT_CONFIG = '''
     },
     "current_game_activity": {
         "CN": "SunlightGirlsNightSong",
-        "Global": "ForWhomTheArtIsForTheFateofDecorativePaintingandAesthetics",
+        "Global": "SerenadePromenade",
         "JP": "JP_2026_04_22"
     },
     "dailyGameActivity": {


### PR DESCRIPTION
国际服复刻了三一偶像活动，我只修改core/config/default_config.py中, "current_game_activity"字段为复刻活动名SerenadePromenade，没有添加其他资源