### PR TITLE
fix : Fix possible crash when Android game launch yields portrait screenshots

### DIFF
--- a/core/Baas_thread.py
+++ b/core/Baas_thread.py
@@ -190,6 +190,8 @@ class Baas_thread:
         return img
 
     def _sync_screenshot_resolution(self, width, height):
+        if not getattr(self, 'resolution', None):
+            return
         if width < height or (width, height) == self.resolution:
             return
         self.logger.warning(

--- a/core/Baas_thread.py
+++ b/core/Baas_thread.py
@@ -167,15 +167,41 @@ class Baas_thread:
                 time.sleep(duration)
 
     def u2_get_screenshot(self):
-        return cv2.cvtColor(np.array(self.u2.screenshot()), cv2.COLOR_RGB2BGR)
+        img = cv2.cvtColor(np.array(self.u2.screenshot()), cv2.COLOR_RGB2BGR)
+        return self.normalize_screenshot(img)
 
     def get_screenshot_array(self):
         if not self.flag_run:
             raise RequestHumanTakeOver
         return self.screenshot.screenshot()
 
+    def normalize_screenshot(self, img):
+        if img is None or img.ndim < 2:
+            return img
+        height, width = img.shape[:2]
+        if self.is_android_device and height > width:
+            self.logger.warning(
+                f"Portrait screenshot detected ({width}x{height}), rotating to landscape."
+            )
+            img = cv2.rotate(img, cv2.ROTATE_90_CLOCKWISE)
+            height, width = img.shape[:2]
+        if self.is_android_device:
+            self._sync_screenshot_resolution(width, height)
+        return img
+
+    def _sync_screenshot_resolution(self, width, height):
+        if width < height or (width, height) == self.resolution:
+            return
+        self.logger.warning(
+            f"Screenshot size {width}x{height} differs from resolution "
+            f"{self.resolution[0]}x{self.resolution[1]}, syncing from screenshot."
+        )
+        self.resolution = (width, height)
+        self.ratio = width / 1280
+        self.logger.info(f"Screen Size Ratio synced: {self.ratio}")
+
     def update_screenshot_array(self):
-        self.latest_img_array = self.get_screenshot_array()
+        self.latest_img_array = self.normalize_screenshot(self.get_screenshot_array())
 
     def signal_stop(self):
         self.flag_run = False
@@ -861,7 +887,9 @@ class Baas_thread:
                 self.u2.uiautomator.start()
                 while not self.u2.uiautomator.running():
                     time.sleep(0.1)
-                self.latest_img_array = cv2.cvtColor(np.array(self.u2.screenshot()), cv2.COLOR_RGB2BGR)
+                self.latest_img_array = self.normalize_screenshot(
+                    cv2.cvtColor(np.array(self.u2.screenshot()), cv2.COLOR_RGB2BGR)
+                )
                 return
             except Exception as e:
                 print(e)

--- a/core/Baas_thread.py
+++ b/core/Baas_thread.py
@@ -173,7 +173,7 @@ class Baas_thread:
     def get_screenshot_array(self):
         if not self.flag_run:
             raise RequestHumanTakeOver
-        return self.screenshot.screenshot()
+        return self.normalize_screenshot(self.screenshot.screenshot())
 
     def normalize_screenshot(self, img):
         if img is None or img.ndim < 2:
@@ -203,7 +203,7 @@ class Baas_thread:
         self.logger.info(f"Screen Size Ratio synced: {self.ratio}")
 
     def update_screenshot_array(self):
-        self.latest_img_array = self.normalize_screenshot(self.get_screenshot_array())
+        self.latest_img_array = self.get_screenshot_array()
 
     def signal_stop(self):
         self.flag_run = False

--- a/core/color.py
+++ b/core/color.py
@@ -21,18 +21,36 @@ def wait_loading(self: Baas_thread) -> None:
     return
 
 
+def _get_rgb_at_index(self, row: int, col: int):
+    img = self.latest_img_array
+    if img is None or img.ndim < 3:
+        return None
+    h, w = img.shape[:2]
+    if not (0 <= row < h and 0 <= col < w):
+        return None
+    return img[row, col]
+
+
+def _pixel_in_rgb_range(pixel, r_min, r_max, g_min, g_max, b_min, b_max):
+    return (r_min <= pixel[2] <= r_max and
+            g_min <= pixel[1] <= g_max and
+            b_min <= pixel[0] <= b_max)
+
+
 def rgb_in_range(self, x: int, y: int, r_min: int, r_max: int, g_min: int, g_max: int, b_min: int, b_max: int,
                  check_nearby=False, nearby_range=1):
-    if r_min <= self.latest_img_array[int(y * self.ratio)][int(x * self.ratio)][2] <= r_max and \
-        g_min <= self.latest_img_array[int(y * self.ratio)][int(x * self.ratio)][1] <= g_max and \
-        b_min <= self.latest_img_array[int(y * self.ratio)][int(x * self.ratio)][0] <= b_max:
+    row = int(y * self.ratio)
+    col = int(x * self.ratio)
+    pixel = _get_rgb_at_index(self, row, col)
+    if pixel is None:
+        return False
+    if _pixel_in_rgb_range(pixel, r_min, r_max, g_min, g_max, b_min, b_max):
         return True
     if check_nearby:
         for i in range(nearby_range * -1, nearby_range + 1):
             for j in range(nearby_range * -1, nearby_range + 1):
-                if r_min <= self.latest_img_array[int(y * self.ratio) + i][int(x * self.ratio) + j][2] <= r_max and \
-                    g_min <= self.latest_img_array[int(y * self.ratio) + i][int(x * self.ratio) + j][1] <= g_max and \
-                    b_min <= self.latest_img_array[int(y * self.ratio) + i][int(x * self.ratio) + j][0] <= b_max:
+                pixel = _get_rgb_at_index(self, row + i, col + j)
+                if pixel is not None and _pixel_in_rgb_range(pixel, r_min, r_max, g_min, g_max, b_min, b_max):
                     return True
     return False
 

--- a/module/restart.py
+++ b/module/restart.py
@@ -29,7 +29,7 @@ def start(self):
         activity_name = None
     self.u2.app_start(self.package_name, activity_name)
     time.sleep(1)
-    if self.server == 'Global':
+    if self.server in ('Global', 'CN', 'JP'):
         self.to_main_page()
         time.sleep(4)
 

--- a/module/restart.py
+++ b/module/restart.py
@@ -28,10 +28,7 @@ def start(self):
     if self.server == 'CN':
         activity_name = None
     self.u2.app_start(self.package_name, activity_name)
-    time.sleep(1)
-    if self.server in ('Global', 'CN', 'JP'):
-        self.to_main_page()
-        time.sleep(4)
+    self.to_main_page()
 
 
 def check_need_restart(self):


### PR DESCRIPTION
1. core/color.py — Add bounds checks in rgb_in_range() so out-of-range pixel reads return False instead of raising IndexError.

2. core/Baas_thread.py — Normalize Android screenshots: auto-rotate portrait captures to landscape and sync resolution/ratio when needed.

3. module/restart.py — After starting the game on CN/JP (same as Global), call to_main_page() and wait 4s before the next task runs.