### PR TITLE
Fix: Adjust create selected item quantity region width

### DIFF
--- a/module/create.py
+++ b/module/create.py
@@ -965,7 +965,7 @@ def get_item_holding_quantity_region(x, y):
 
 
 def get_item_selected_quantity_region(x, y):
-    dx = 103
+    dx = 83
     dy = 25
     return x, y, x + dx, y + dy
 


### PR DESCRIPTION
在制造选择紫色材料时，由于OCR识别范围过长，会将右侧竖边错误识别成1，所以我调整了OCR识别的范围。