### PR TITLE
fix(gui): 修复深色模式下多处文本呈黑色的问题

### DIFF
--- a/gui/components/expand/featureSwitch.py
+++ b/gui/components/expand/featureSwitch.py
@@ -78,7 +78,6 @@ class Layout(QWidget):
         assert self._event_config is not None
         self._crt_order_config = self._event_config
         self.config.get_signal('update_signal').connect(self._refresh_time)
-        self._theme_connected_labels = []
         configGui.themeChanged.connect(self._on_theme_changed)
 
         self.boxes, self.qLabels, self.times, self.check_boxes, self.config_buttons = [], [], [], [], []
@@ -157,19 +156,19 @@ class Layout(QWidget):
             self.config_buttons.append(cfbs_wrapper)
 
     def _make_event_label(self, text: str) -> CaptionLabel:
-        """Create a CaptionLabel with correct text color for the current theme,
-        and register it for automatic updates when the theme changes."""
+        """Create a CaptionLabel with correct text color for the current theme."""
         label = CaptionLabel(text)
         color = COLOR_THEME[configGui.theme.value]['text']
         label.setStyleSheet(f'color: {color};')
-        self._theme_connected_labels.append(label)
         return label
 
     def _on_theme_changed(self):
         """Update all event labels when the theme switches."""
         color = COLOR_THEME[configGui.theme.value]['text']
-        for label in self._theme_connected_labels:
+        for label in self.qLabels:
             label.setStyleSheet(f'color: {color};')
+        if hasattr(self, 'label_3'):
+            self.label_3.setStyleSheet(f'color: {color};')
 
     def _read_config(self):
         with open(self.config.config_dir + '/event.json', 'r', encoding='utf-8') as f:
@@ -186,7 +185,6 @@ class Layout(QWidget):
         temp = deepcopy(self._event_config)
         # clear original components
         self.qLabels, self.times, self.check_boxes = [], [], []
-        self._theme_connected_labels = []  # discard refs to old destroyed labels
         self.tableView.clearContents()
         self.vBox.removeWidget(self.tableView)
         self.tableView.deleteLater()

--- a/gui/components/expand/featureSwitch.py
+++ b/gui/components/expand/featureSwitch.py
@@ -10,6 +10,7 @@ from qfluentwidgets import CheckBox, TableWidget, PushButton, ComboBox, CaptionL
     SubtitleLabel
 
 from gui.components.expand.expandTemplate import TemplateLayoutV2
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.customized_ui import ClickFocusLineEdit
 from gui.util.translator import baasTranslator as bt
 
@@ -77,6 +78,8 @@ class Layout(QWidget):
         assert self._event_config is not None
         self._crt_order_config = self._event_config
         self.config.get_signal('update_signal').connect(self._refresh_time)
+        self._theme_connected_labels = []
+        configGui.themeChanged.connect(self._on_theme_changed)
 
         self.boxes, self.qLabels, self.times, self.check_boxes, self.config_buttons = [], [], [], [], []
         self._init_components(self._event_config)
@@ -94,7 +97,7 @@ class Layout(QWidget):
         self.op_2.clicked.connect(self._refresh)
 
         self.option_layout.addStretch(1)
-        self.label_3 = CaptionLabel(self.tr('排序方式：'), self)
+        self.label_3 = self._make_event_label(self.tr('排序方式：'))
         self.op_3 = ComboBox(self)
         self.op_3.addItems([self.tr('默认排序'), self.tr('按下次执行时间排序')])
 
@@ -133,7 +136,7 @@ class Layout(QWidget):
             cbx_layout.addWidget(t_cbx, 1, Qt.AlignCenter)
             cbx_layout.setContentsMargins(30, 0, 0, 0)
             cbx_wrapper.setLayout(cbx_layout)
-            t_ccs = CaptionLabel(bt.tr('ConfigTranslation', self.labels[i]), self)
+            t_ccs = self._make_event_label(bt.tr('ConfigTranslation', self.labels[i]))
             t_ncs = ClickFocusLineEdit(self)
             t_ncs.setClearButtonEnabled(True)
             t_ncs.setText(str(datetime.fromtimestamp(self.next_ticks[i])).split('.')[0])
@@ -153,6 +156,21 @@ class Layout(QWidget):
             cfbs_wrapper.setLayout(cfbs_layout)
             self.config_buttons.append(cfbs_wrapper)
 
+    def _make_event_label(self, text: str) -> CaptionLabel:
+        """Create a CaptionLabel with correct text color for the current theme,
+        and register it for automatic updates when the theme changes."""
+        label = CaptionLabel(text)
+        color = COLOR_THEME[configGui.theme.value]['text']
+        label.setStyleSheet(f'color: {color};')
+        self._theme_connected_labels.append(label)
+        return label
+
+    def _on_theme_changed(self):
+        """Update all event labels when the theme switches."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_connected_labels:
+            label.setStyleSheet(f'color: {color};')
+
     def _read_config(self):
         with open(self.config.config_dir + '/event.json', 'r', encoding='utf-8') as f:
             s = f.read()
@@ -168,6 +186,7 @@ class Layout(QWidget):
         temp = deepcopy(self._event_config)
         # clear original components
         self.qLabels, self.times, self.check_boxes = [], [], []
+        self._theme_connected_labels = []  # discard refs to old destroyed labels
         self.tableView.clearContents()
         self.vBox.removeWidget(self.tableView)
         self.tableView.deleteLater()
@@ -188,7 +207,8 @@ class Layout(QWidget):
         self._crt_order_config = temp
         # Add components to table
         for ind, unit in enumerate(temp):
-            t_ccs = CaptionLabel(bt.tr('ConfigTranslation', unit['event_name']))
+            # t_ccs = CaptionLabel(bt.tr('ConfigTranslation', unit['event_name']))
+            t_ccs = self._make_event_label(bt.tr('ConfigTranslation', unit['event_name']))
             self.tableView.setCellWidget(ind, 0, t_ccs)
             self.qLabels.append(t_ccs)
 

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -19,6 +19,7 @@ from qfluentwidgets import (
 )
 
 from core.notification import notify
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.customized_ui import AssetsWidget, FuncLabel
 from gui.util.translator import baasTranslator as bt
 from window import Window
@@ -59,6 +60,10 @@ class HomeFragment(QFrame):
         self.infoLayout.addWidget(self.label, 0, Qt.AlignLeft)
         self.infoLayout.addStretch(1)
         self.infoLayout.addWidget(self.info, 0, Qt.AlignRight)
+
+        self._theme_labels = [self.label, self.info]
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
         self.banner = FuncLabel(self)
         self.banner.setFixedHeight(200)
@@ -160,6 +165,12 @@ class HomeFragment(QFrame):
         self.setObjectName(f"{self.object_name}.HomeFragment")
         if self.config.get('autostart'):
             self.startup_card.button.click()
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by QFrame not propagating theme palette."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_labels:
+            label.setStyleSheet(f'color: {color};')
 
     @pyqtSlot(int, str)
     def on_log_received(self, level: int, message: str) -> None:

--- a/gui/fragments/process.py
+++ b/gui/fragments/process.py
@@ -9,6 +9,7 @@ from qfluentwidgets import (ScrollArea, TitleLabel, SubtitleLabel, ListWidget, S
                             ToolTipPosition, ToolTipFilter)
 
 from gui.components import expand
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.style_sheet import StyleSheet
 from gui.util.translator import baasTranslator as bt
 
@@ -27,9 +28,9 @@ class ProcessFragment(ScrollArea):
         self.titleLineLayout = QHBoxLayout()
         _scheduler_selector = config.get('new_event_enable_state')
         _scheduler_selector_layout = QHBoxLayout()
-        _scheduler_selector_label = SubtitleLabel(self.tr("调度状态"), self)
-        _scheduler_selector_label.setToolTip(self.tr("当BAAS新增调度任务时的启用状态"))
-        _scheduler_selector_label.installEventFilter(ToolTipFilter(_scheduler_selector_label, position=ToolTipPosition.TOP))
+        self._scheduler_selector_label = SubtitleLabel(self.tr("调度状态"), self)
+        self._scheduler_selector_label.setToolTip(self.tr("当BAAS新增调度任务时的启用状态"))
+        self._scheduler_selector_label.installEventFilter(ToolTipFilter(self._scheduler_selector_label, position=ToolTipPosition.TOP))
 
         __dict__for_scheduler_selector = {
             '开': 'on',
@@ -47,7 +48,7 @@ class ProcessFragment(ScrollArea):
         self.scheduler_selector.setCurrentText(bt.tr('ConfigTranslation', _raw_scheduler_selector))
         self.scheduler_selector.currentTextChanged.connect(
             lambda x: config.set('new_event_enable_state', __dict__for_scheduler_selector[bt.undo(x)]))
-        _scheduler_selector_layout.addWidget(_scheduler_selector_label)
+        _scheduler_selector_layout.addWidget(self._scheduler_selector_label)
         _scheduler_selector_layout.addWidget(self.scheduler_selector)
 
         self.titleLineLayout.addWidget(self.settingLabel, 1, Qt.AlignLeft)
@@ -74,6 +75,12 @@ class ProcessFragment(ScrollArea):
 
         self.vBox2.addWidget(self.label_queuing)
         self.vBox2.addWidget(self.listWidget)
+
+        self._theme_labels = [
+            self.settingLabel, self._scheduler_selector_label,
+            self.label_running, self.label_queuing
+        ]
+        configGui.themeChanged.connect(self._apply_label_colors)
 
         self.HBoxLayout.addLayout(self.vBox1)
         self.HBoxLayout.addLayout(self.vBox2)
@@ -135,3 +142,10 @@ class ProcessFragment(ScrollArea):
         self.listWidget.setObjectName('listWidget')
         StyleSheet.PROCESS.apply(self.on_status)
         StyleSheet.PROCESS.apply(self.listWidget)
+        self._apply_label_colors()
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_labels:
+            label.setStyleSheet(f'color: {color};')

--- a/gui/fragments/settings.py
+++ b/gui/fragments/settings.py
@@ -12,7 +12,7 @@ import window
 from gui.components import expand
 from gui.components.template_card import SimpleSettingCard
 from gui.util import notification
-from gui.util.config_gui import configGui, isWin11
+from gui.util.config_gui import configGui, isWin11, COLOR_THEME
 from gui.util.language import Language
 
 
@@ -206,6 +206,8 @@ class SettingsFragment(ScrollArea):
         self.expandLayout.addWidget(self.guiGroup)
 
         self.setWidget(self.scrollWidget)
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
     def __showRestartTooltip(self):
         """ show restart tooltip """
@@ -227,3 +229,8 @@ class SettingsFragment(ScrollArea):
         self.themeCard.optionChanged.connect(lambda ci: setTheme(configGui.get(ci)))
         self.themeColorCard.colorChanged.connect(lambda c: setThemeColor(c))
         self.micaCard.checkedChanged.connect(lambda x: configGui.micaEnableChanged.emit(x))
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        self.settingLabel.setStyleSheet(f'color: {color};')

--- a/gui/fragments/switch.py
+++ b/gui/fragments/switch.py
@@ -13,7 +13,7 @@ from qfluentwidgets import SettingCardGroup
 
 from gui.components import expand
 from gui.components.template_card import TemplateSettingCard, TemplateSettingCardForClick
-from gui.util.config_gui import configGui
+from gui.util.config_gui import configGui, COLOR_THEME
 
 lock = threading.Lock()
 
@@ -273,9 +273,16 @@ class SwitchFragment(ScrollArea):
         self.viewport().setStyleSheet("background-color: transparent;")
         self.expandLayout.addWidget(self.settingLabel)
         self.update_settings()
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
     def __initWidget(self):
         """
         Sets the scrollable widget for the scroll area.
         """
         self.setWidget(self.scrollWidget)
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        self.settingLabel.setStyleSheet(f'color: {color};')

--- a/gui/qss/light/process.qss
+++ b/gui/qss/light/process.qss
@@ -2,6 +2,7 @@
     font-size: 18px;
     padding: 10px;
     font-weight: bold;
+    color: #333333;
     background-color: #e0f0e0;
     border-radius: 10px;
 }

--- a/gui/util/customized_ui.py
+++ b/gui/util/customized_ui.py
@@ -411,6 +411,7 @@ class AssetsWidget(QFrame):
                 font-size: %(line_height)dpx;
                 line-height: %(item_height)dpx;
                 border: none;
+                color: %(text_color)s;
             }
 
             QToolTip {
@@ -424,6 +425,7 @@ class AssetsWidget(QFrame):
         """ % {
             'background_color': COLOR_THEME[configGui.theme.value]['background'],
             'border_color': COLOR_THEME[configGui.theme.value]['border'],
+            'text_color': COLOR_THEME[configGui.theme.value]['text'],
             'line_height': (self.item_height - 10) // 2,
             'item_height': self.item_height
         })


### PR DESCRIPTION
fix #553
### 修复概述 (Summary)
修复了深色模式与浅色模式下 GUI 界面多处文本颜色异常、对比度不足导致无法正常阅读的问题。

### 修复方案 (Implementation Details)
1. **显式主题颜色绑定与动态更新**：
   - 针对受 `QScrollArea` 样式继承截断影响的各个 Fragment（`ProcessFragment`, `HomeFragment`, `SwitchFragment`, `SettingsFragment`），使用项目规范的 `configGui.themeChanged` 信号与 `COLOR_THEME` 机制，在初始化及主题切换时显式更新受影响 Label 的文字颜色。
2. **调度表格单元格适配**：
   - 在 `featureSwitch.py` 中引入 `_make_event_label()` 与 `_on_theme_changed()`，为 `CaptionLabel` 动态赋予当前主题颜色，并在 `_sort()` 重建表格时清理失效引用，防止内存泄漏。
3. **补充 QSS 样式表与资产组件缺失的文字颜色**：
   - 在 `gui/qss/light/process.qss` 的 `#on_status` 补充 `color: #333333;`。
   - 在 `customized_ui.py` 的 `AssetsWidget.repaint_color()` 中为 `QLabel` 注入 `COLOR_THEME[theme]['text']`。

### 涉及修改文件 (Modified Files)
- `gui/components/expand/featureSwitch.py`: 修复表格事件列与排序提示文字颜色，支持动态主题切换及排序重建。
- `gui/fragments/process.py`: 修复调度页标题与副标题颜色。
- `gui/fragments/home.py`: 修复主页标题与状态副标题颜色。
- `gui/fragments/switch.py`: 修复配置页主标题颜色。
- `gui/fragments/settings.py`: 修复普通设置页主标题颜色。
- `gui/qss/light/process.qss`: 补充浅色模式下 `#on_status` 文本颜色。
- `gui/util/customized_ui.py`: 补充 `AssetsWidget` 资产显示文字颜色。

### 测试验证 (Verification)
- [x] 深色模式下：主页、调度页、配置页、设置页所有标题、表格文字、资产文字均清晰显示为白色。
- [x] 浅色模式下：各页面标题及调度状态「暂无正在执行的任务」均清晰显示为深灰色。
- [x] 运行中动态切换深浅色主题，界面实时响应无报错。
- [x] 调度页点击排序切换后，文字颜色正常且无对象引用异常。