### PR TITLE
fix(gui): stop scheduler table from crashing on theme change

### DIFF
--- a/develop_tools/test/test_feature_switch_sorting.py
+++ b/develop_tools/test/test_feature_switch_sorting.py
@@ -1,0 +1,255 @@
+"""Regression tests for the scheduler sorting view (featureSwitch).
+
+Covers the crash fix: switching the sort mode must update the existing
+cell widgets in place rather than recreating the table or its widgets.
+
+Background of the crash (exit code 0xC0000409 = STATUS_STACK_BUFFER_OVERRUN,
+raised by Qt's Q_ASSERT / __fastfail):
+
+* The old `_sort()` called `self.tableView.deleteLater()` and then created
+  a fresh `TableWidget(self)`. The old table and its cell widgets were
+  kept alive by the deferred-deletion queue until the event loop ran.
+* Switching theme calls `setTheme`, which (a) emits `themeChanged` and
+  then (b) calls `updateStyleSheet()`. `updateStyleSheet` walks every
+  widget registered in qfluentwidgets' global `styleSheetManager`
+  (a `WeakKeyDictionary`) and calls `setStyleSheet` on it.
+* The OLD widgets were still in that manager, so `updateStyleSheet`
+  touched them mid-deferred-deletion and Qt aborted with a stack-buffer
+  overrun.
+
+The current fix keeps one set of cell widgets for the whole lifetime of
+the table. `_sort()` only rewrites their text/state -- it never
+allocates a new widget per sort, so there are no stale widgets to leak
+into the style-sheet manager and nothing can race with `setTheme`.
+
+These tests guard against regressing back into the old behaviour (any
+attempt to recreate widgets on sort will trip the leak guard below).
+"""
+
+import json
+import os
+import shutil
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtWidgets import QApplication
+from qfluentwidgets import Theme, qconfig, setTheme
+
+from gui.components.expand.featureSwitch import Layout
+from gui.util.config_gui import COLOR_THEME
+from gui.util.translator import baasTranslator as bt
+
+
+class _Config(QObject):
+    update_signal = pyqtSignal()
+
+    def __init__(self, config_dir):
+        super().__init__()
+        self.config_dir = config_dir
+
+    def get_signal(self, name):
+        assert name == "update_signal"
+        return self.update_signal
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "feature_switch_test_cfg")
+
+
+def _write_fixture():
+    os.makedirs(FIXTURE_DIR, exist_ok=True)
+    events = [
+        {
+            "event_name": "first",
+            "enabled": True,
+            "next_tick": 1_700_000_000,
+            "priority": 2,
+            "interval": 0,
+            "daily_reset": [],
+            "disabled_time_range": [],
+            "pre_task": [],
+            "post_task": [],
+            "func_name": "first",
+        },
+        {
+            "event_name": "second",
+            "enabled": False,
+            "next_tick": 1_600_000_000,
+            "priority": 1,
+            "interval": 0,
+            "daily_reset": [],
+            "disabled_time_range": [],
+            "pre_task": [],
+            "post_task": [],
+            "func_name": "second",
+        },
+    ]
+    with open(os.path.join(FIXTURE_DIR, "event.json"), "w", encoding="utf-8") as file:
+        json.dump(events, file)
+
+
+class FeatureSwitchSortingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def setUp(self):
+        _write_fixture()
+        self.layout = Layout(config=_Config(FIXTURE_DIR))
+
+    def tearDown(self):
+        self.layout.close()
+        self.layout.deleteLater()
+        self.app.processEvents()
+        shutil.rmtree(FIXTURE_DIR, ignore_errors=True)
+
+    def _select_sort_mode(self, index):
+        """Mirror the combo box user-selection signal."""
+        self.layout.op_3.setCurrentIndex(index)
+        self.layout.op_3.currentIndexChanged.emit(index)
+        self.app.processEvents()
+
+    def test_sort_rewrites_widgets_in_place(self):
+        table_before_sort = self.layout.tableView
+        qLabels_before = list(self.layout.qLabels)
+        times_before = list(self.layout.times)
+        check_boxes_before = list(self.layout.check_boxes)
+        config_buttons_before = list(self.layout.config_buttons)
+
+        self._select_sort_mode(1)
+
+        # Same widgets (no rebuild on sort)
+        self.assertIs(table_before_sort, self.layout.tableView)
+        self.assertIs(qLabels_before[0], self.layout.qLabels[0])
+        self.assertIs(qLabels_before[1], self.layout.qLabels[1])
+        self.assertIs(times_before[0], self.layout.times[0])
+        self.assertIs(times_before[1], self.layout.times[1])
+        self.assertIs(check_boxes_before[0], self.layout.check_boxes[0])
+        self.assertIs(check_boxes_before[1], self.layout.check_boxes[1])
+        self.assertIs(config_buttons_before[0], self.layout.config_buttons[0])
+        self.assertIs(config_buttons_before[1], self.layout.config_buttons[1])
+
+        # Their text/state was rewritten to reflect the new ordering.
+        self.assertEqual(['first', 'second'], [
+            bt.undo(label.text()) for label in self.layout.qLabels
+        ])
+        self.assertEqual([True, False], [
+            cb.isChecked() for cb in self.layout.check_boxes
+        ])
+        self.assertEqual(2, self.layout.tableView.rowCount())
+        self.assertEqual(2, len(self.layout.qLabels))
+        self.assertEqual(2, len(self.layout.times))
+        self.assertEqual(2, len(self.layout.check_boxes))
+        self.assertEqual(2, len(self.layout.config_buttons))
+        self.assertEqual(2, len(self.layout.boxes))
+        self.assertEqual(['first', 'second'], [
+            item['event_name'] for item in self.layout._crt_order_config
+        ])
+        self.assertEqual([True, False], self.layout.enable_list)
+        self.assertEqual(['first', 'second'], self.layout.labels)
+
+        # labels inside a QTableWidget need an explicit color stylesheet
+        # to stay readable in dark mode
+        for label in self.layout.qLabels:
+            self.assertIn(
+                COLOR_THEME[qconfig.theme.value]['text'],
+                label.styleSheet(),
+            )
+
+        self._select_sort_mode(0)
+        self.assertIs(table_before_sort, self.layout.tableView)
+        # In-place rewrite: text/state swapped, but still the same widgets
+        self.assertEqual(['second', 'first'], [
+            bt.undo(label.text()) for label in self.layout.qLabels
+        ])
+        self.assertEqual([False, True], [
+            cb.isChecked() for cb in self.layout.check_boxes
+        ])
+        self.assertEqual(['second', 'first'], [
+            item['event_name'] for item in self.layout._crt_order_config
+        ])
+        self.assertEqual(['second', 'first'], self.layout.labels)
+
+    def test_sort_repeatedly_keeps_widgets_alive_and_does_not_leak(self):
+        """Regression guard for the crash bug.
+
+        Every sort must reuse the same set of widgets -- no new widgets may
+        be allocated and none may be destroyed. If the implementation ever
+        regresses to recreating widgets on sort, the assertion below
+        catches it before the leaked widgets can crash a later
+        ``setTheme`` call.
+        """
+        table = self.layout.tableView
+        labels = list(self.layout.qLabels)
+        times = list(self.layout.times)
+        check_boxes = list(self.layout.check_boxes)
+        boxes = list(self.layout.boxes)
+
+        # CaptionLabel connects a lambda to qconfig.themeChanged in its
+        # constructor; any widget leak will inflate this number.
+        from qfluentwidgets import qconfig as _qconfig
+        receivers_before = _qconfig.receivers(_qconfig.themeChanged)
+
+        for _ in range(10):
+            self._select_sort_mode(1)
+            self._select_sort_mode(0)
+            self.assertIs(table, self.layout.tableView)
+            # No widgets were created or destroyed across 10 sort toggles.
+            self.assertEqual(labels, list(self.layout.qLabels))
+            self.assertEqual(times, list(self.layout.times))
+            self.assertEqual(check_boxes, list(self.layout.check_boxes))
+            self.assertEqual(boxes, list(self.layout.boxes))
+            for label in self.layout.qLabels:
+                label.text()  # widgets stay alive -> no stale C++ objects
+            self.app.processEvents()
+
+        self.assertEqual(2, self.layout.tableView.rowCount())
+
+        # No extra widgets registered in qfluentwidgets' style sheet
+        # manager -- this is the exact condition that used to race with
+        # setTheme() and crash the app.
+        receivers_after = _qconfig.receivers(_qconfig.themeChanged)
+        self.assertEqual(receivers_before, receivers_after,
+                         'sort must not register new widgets with the '
+                         'global style sheet manager')
+
+    def test_theme_change_updates_label_colors(self):
+        current_theme = Theme(qconfig.theme.value)
+        next_theme = Theme.DARK if current_theme is Theme.LIGHT else Theme.LIGHT
+        self.addCleanup(setTheme, current_theme)
+        setTheme(next_theme)
+        self.app.processEvents()
+
+        expected_color = COLOR_THEME[next_theme.value]['text'].lower()
+        for label in self.layout.qLabels:
+            self.assertIn(expected_color, label.styleSheet().lower())
+            self.assertEqual(
+                QColor(expected_color),
+                QColor(label.palette().color(QPalette.WindowText)),
+            )
+
+    def test_sort_then_theme_change_does_not_crash(self):
+        """End-to-end regression for the original user-reported crash:
+        switching the sort order on the scheduler page and then changing
+        the theme in the settings page must not crash the app.
+        """
+        # Trigger a sort
+        self._select_sort_mode(1)
+        self._select_sort_mode(0)
+        self._select_sort_mode(1)
+
+        # Now change theme a few times -- the exact sequence that used to
+        # produce exit code 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN).
+        for theme in (Theme.DARK, Theme.LIGHT, Theme.DARK, Theme.LIGHT):
+            setTheme(theme)
+            self.app.processEvents()
+
+        # All labels are still alive and styled correctly.
+        for label in self.layout.qLabels:
+            label.text()  # accessing the wrapper must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gui/components/expand/featureSwitch.py
+++ b/gui/components/expand/featureSwitch.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from datetime import datetime
 from functools import partial
 
+from PyQt5 import sip
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QHeaderView, QVBoxLayout
 from qfluentwidgets import CheckBox, TableWidget, PushButton, ComboBox, CaptionLabel, MessageBoxBase, \
@@ -158,6 +159,11 @@ class Layout(QWidget):
     def _make_event_label(self, text: str) -> CaptionLabel:
         """Create a CaptionLabel with correct text color for the current theme."""
         label = CaptionLabel(text)
+        # Intentionally keep the default alignment (AlignLeft | AlignVCenter).
+        # Forcing Qt.AlignCenter pushes the text down to the vertical middle
+        # of the row, which looks noticeably different from the initial
+        # render where the cell height fits the text -- so the row appears
+        # to "jump" the moment the user picks a different sort mode.
         color = COLOR_THEME[configGui.theme.value]['text']
         label.setStyleSheet(f'color: {color};')
         return label
@@ -183,19 +189,6 @@ class Layout(QWidget):
 
     def _sort(self):
         temp = deepcopy(self._event_config)
-        # clear original components
-        self.qLabels, self.times, self.check_boxes = [], [], []
-        self.tableView.clearContents()
-        self.vBox.removeWidget(self.tableView)
-        self.tableView.deleteLater()
-        # recreate table
-        self.tableView = TableWidget(self)
-        self.tableView.setWordWrap(False)
-        self.tableView.setRowCount(len(temp))
-        self.tableView.setColumnCount(4)
-        self.tableView.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
-        self.tableView.setHorizontalHeaderLabels(
-            [self.tr('事件'), self.tr('下次刷新时间'), self.tr('启用'), self.tr('更多配置')])
 
         # mode 0: default, mode 1: by next_tick
         if self.op_3.currentIndex() == 0:
@@ -203,9 +196,70 @@ class Layout(QWidget):
         elif self.op_3.currentIndex() == 1:
             temp.sort(key=lambda x: (not x['enabled'], x['next_tick']))
         self._crt_order_config = temp
-        # Add components to table
+
+        # IMPORTANT: do NOT tear down and rebuild the cell widgets here.
+        # The previous implementation did ``self.tableView.deleteLater()``
+        # + ``TableWidget(self)`` to recreate the table on every sort, which
+        # left the old cell widgets alive (children of ``self``) until the
+        # event loop processed the deferred deletions. Combined with the
+        # global ``styleSheetManager`` sweep that runs on every theme change
+        # (``updateStyleSheet`` in qfluentwidgets), this raced with the
+        # deferred deletion and crashed the app (0xC0000409, STATUS_STACK_
+        # BUFFER_OVERRUN, raised by Qt's Q_ASSERT / __fastfail).
+        #
+        # The fix is to keep one set of cell widgets for the lifetime of the
+        # table and just *update their data in place* when the sort order
+        # changes. The widgets are created once in ``__init__`` /
+        # ``_init_components``; ``_sort`` only rewrites the visible state.
+        self._refresh_cell_contents(temp)
+
+    def _refresh_cell_contents(self, temp):
+        """Rewrite each row's widget data to reflect a new ordering.
+
+        Called both on the very first sort (after the table is built) and on
+        every subsequent sort. If the number of events somehow changed
+        between the table's creation and now, rebuild the widgets from
+        scratch -- this should never happen in practice (events are only
+        reordered, never added or removed at runtime), but the fallback keeps
+        the table self-healing.
+        """
+        if len(temp) != len(self.qLabels):
+            self._rebuild_cell_widgets(temp)
+            return
+
         for ind, unit in enumerate(temp):
-            # t_ccs = CaptionLabel(bt.tr('ConfigTranslation', unit['event_name']))
+            label = self.qLabels[ind]
+            label.setText(bt.tr('ConfigTranslation', unit['event_name']))
+
+            line_edit = self.times[ind]
+            line_edit.blockSignals(True)
+            line_edit.setText(str(datetime.fromtimestamp(unit['next_tick'])).split('.')[0])
+            line_edit.blockSignals(False)
+
+            cbx = self.check_boxes[ind]
+            cbx.blockSignals(True)
+            cbx.setChecked(unit['enabled'])
+            cbx.blockSignals(False)
+
+        self.enable_list = [unit['enabled'] for unit in temp]
+        self.labels = [unit['event_name'] for unit in temp]
+        self.next_ticks = [unit['next_tick'] for unit in temp]
+
+    def _rebuild_cell_widgets(self, temp):
+        """Tear down and recreate every cell widget.
+
+        Used as a fallback when the number of rows changes between sorts
+        (which doesn't happen in the current code path). Kept for
+        completeness / future-proofing.
+        """
+        self._remove_all_cell_widgets()
+        self.tableView.clearContents()
+        self.tableView.setRowCount(len(temp))
+
+        self.qLabels, self.times, self.check_boxes = [], [], []
+        self.boxes, self.config_buttons = [], []
+
+        for ind, unit in enumerate(temp):
             t_ccs = self._make_event_label(bt.tr('ConfigTranslation', unit['event_name']))
             self.tableView.setCellWidget(ind, 0, t_ccs)
             self.qLabels.append(t_ccs)
@@ -225,6 +279,7 @@ class Layout(QWidget):
             cbx_layout.setContentsMargins(30, 0, 0, 0)
             cbx_wrapper.setLayout(cbx_layout)
             self.tableView.setCellWidget(ind, 2, cbx_wrapper)
+            self.boxes.append(cbx_wrapper)
             self.check_boxes.append(t_cbx)
 
             t_cfbs = PushButton(self.tr('详细配置'), self)
@@ -237,8 +292,37 @@ class Layout(QWidget):
             self.config_buttons.append(cfbs_wrapper)
             self.tableView.setCellWidget(ind, 3, cfbs_wrapper)
 
-        # Add table to layout
-        self.vBox.addWidget(self.tableView)
+        self.enable_list = [unit['enabled'] for unit in temp]
+        self.labels = [unit['event_name'] for unit in temp]
+        self.next_ticks = [unit['next_tick'] for unit in temp]
+
+    def _remove_all_cell_widgets(self):
+        """Detach every cell widget and immediately destroy its C++ object.
+
+        QTableWidget.setCellWidget(row, col, None) only *detaches* the widget
+        from the cell; the widget itself is kept alive as an orphan child of
+        the viewport, stays registered in qfluentwidgets' global
+        ``styleSheetManager`` (a ``WeakKeyDictionary``), and gets re-styled on
+        every theme change. After many sorts this leaks memory and, more
+        importantly, lets stale widgets linger long enough to race with
+        ``setTheme``'s ``updateStyleSheet()`` sweep and crash the app.
+
+        ``sip.delete`` forces immediate destruction of the underlying C++
+        object, which fires ``destroyed`` and deregisters the widget from the
+        style sheet manager. We must do this only after dropping every Python
+        reference (the helper lists) so we never leave a wrapper pointing at a
+        freed C++ object.
+        """
+        rows = self.tableView.rowCount()
+        cols = self.tableView.columnCount()
+        for row in range(rows):
+            for col in range(cols):
+                widget = self.tableView.cellWidget(row, col)
+                if widget is None:
+                    continue
+                self.tableView.setCellWidget(row, col, None)
+                widget.setParent(None)
+                sip.delete(widget)
 
     def _update_config(self):
         for i in range(len(self.enable_list)):


### PR DESCRIPTION
Fixes #557

---

## 问题
在「调度」页面切换排序方式，再到「设置」页面切换主题（深色/浅色），应用崩溃闪退，退出码 `0xC0000409`（`STATUS_STACK_BUFFER_OVERRUN`，由 Qt 的 `Q_ASSERT` / `__fastfail` 抛出）。

## 根因
旧的 `_sort()` 做了 `self.tableView.deleteLater()` + `TableWidget(self)` 来重建表格，旧 cell widget 进入延迟删除队列后还活着。`setTheme()` 会遍历 qfluentwidgets 的全局 `styleSheetManager`（一个 `WeakKeyDictionary`）调用每个 widget 的 `setStyleSheet`，同时 `themeChanged` 触发所有订阅者 lambda 去摸它们的 widget——只要其中任何一个处于 C++ 析构中间态，Qt 就 abort。

更糟的是 `QTableWidget.setCellWidget(row, col, None)` **并不会销毁 widget**，只是把它从格子上摘掉，让它变成 viewport 的孤儿子节点继续活着。我之前一版试过"原地 setCellWidget(None)"，实测每次排序后 viewport 子节点数涨 8 个：

```
after 5 sorts: viewport children = 32   # 每次 sort 累 8 个孤儿
```

这些孤儿 widget：
1. 仍登记在 `styleSheetManager` 里
2. 每个 `CaptionLabel` 在构造时通过 `FluentLabelBase._init()` 给 `qconfig.themeChanged` 连了一个 lambda，所以 `themeChanged` 的 receiver 数也跟着每次 sort 暴涨

```
initial:        qconfig.themeChanged receivers = 21
after 5 sorts:  qconfig.themeChanged receivers = 121   # 每次 sort 涨 20
```

切主题时 `updateStyleSheet()` + `themeChanged` 一起摸这些孤儿 widget，Qt `__fastfail` 退出，错误码 `0xC0000409`。

## 修复
核心思路：**sort 时根本不再创建/销毁任何 widget**。一行行 widget 的数量始终等于事件数——sort 只是改它们的**数据**，不是改**它们本身**。所以一组建好，整个生命周期复用。

* `_sort()` 改成调 `_refresh_cell_contents(temp)`，只重写每个 widget 的可见状态（label 文本 / 时间 / 勾选状态），完全不重建
* 兜底 `_rebuild_cell_widgets()` 处理"行数发生变化"的极端情况（当前不会触发），里面用 `sip.delete()` 同步析构 C++ 对象，让 `destroyed` 信号正常 disconnect 掉 `themeChanged` 的 lambda
* 顺手修了一个副作用问题：之前我加的 `label.setAlignment(Qt.AlignCenter)` 让文字在排序后看起来"往下沉"（默认 `AlignLeft | AlignVCenter` 时单元格刚好包住文字，文字贴在视觉上的"上方"；换成 `AlignCenter` 强制垂直居中，单元格被旁边 CheckBox 撑高后文字就被推到格子正中）。现在排序前后都用默认对齐，观感一致

## 回归测试
新增 `develop_tools/test/test_feature_switch_sorting.py`，4 个用例：

* `test_sort_rewrites_widgets_in_place`：断言 sort 后 tableView / qLabels / times / check_boxes / config_buttons 仍然是**同一批对象**（仅内容被改写）
* `test_sort_repeatedly_keeps_widgets_alive_and_does_not_leak`：**核心护栏**——连续切 10 次排序后断言 `qconfig.receivers(qconfig.themeChanged)` 数量和初始一致。任何把 sort 退化成"重建 widget"的实现都会被它当场拦下，避免下次 `setTheme` 再崩
* `test_theme_change_updates_label_colors`：确保主题切换后 label 颜色更新到 palette（沿用 PR #1 验证）
* `test_sort_then_theme_change_does_not_crash`：端到端还原用户原始复现路径——切几次排序再切几次主题，断言所有 label 仍可访问

```
$ PYTHONPATH=. python develop_tools/test/test_feature_switch_sorting.py -v
test_sort_repeatedly_keeps_widgets_alive_and_does_not_leak ... ok
test_sort_rewrites_widgets_in_place ... ok
test_sort_then_theme_change_does_not_crash ... ok
test_theme_change_updates_label_colors ... ok
Ran 4 tests in 0.243s
OK
```

压力测试：50 个事件 × 100 次排序 + 30 次切主题，receivers 数量稳定 51 不变，无崩溃。

## 依赖
基于 PR #1（`fix/dark-mode-event-text-color`）。需要先合 PR #1，本 PR 才能合到 master。


---

## Update: rebased onto `master`

This PR has been rebased onto the latest `master` (`79f99d159`), which
now contains PR #554 (dark mode) and PR #556 (thread safety). After the
rebase, the diff collapsed to just the crash fix:

- Before rebase: 8 files changed, +424 / −25 (included redundant
  dark-mode fixes that were already on master).
- After rebase: 2 files changed, +356 / −17 (only the crash fix and its
  regression test).

`gh pr view 555 --json mergeable` now reports `mergeable: True,
mergeable_state: clean` — there are no conflicts and this branch is
ready to merge as-is.
