### PR TITLE
fix(gui): update scheduler status widgets on the GUI thread

### DIFF
--- a/gui/components/expand/featureSwitch.py
+++ b/gui/components/expand/featureSwitch.py
@@ -78,7 +78,6 @@ class Layout(QWidget):
         assert self._event_config is not None
         self._crt_order_config = self._event_config
         self.config.get_signal('update_signal').connect(self._refresh_time)
-        self._theme_connected_labels = []
         configGui.themeChanged.connect(self._on_theme_changed)
 
         self.boxes, self.qLabels, self.times, self.check_boxes, self.config_buttons = [], [], [], [], []
@@ -157,19 +156,19 @@ class Layout(QWidget):
             self.config_buttons.append(cfbs_wrapper)
 
     def _make_event_label(self, text: str) -> CaptionLabel:
-        """Create a CaptionLabel with correct text color for the current theme,
-        and register it for automatic updates when the theme changes."""
+        """Create a CaptionLabel with correct text color for the current theme."""
         label = CaptionLabel(text)
         color = COLOR_THEME[configGui.theme.value]['text']
         label.setStyleSheet(f'color: {color};')
-        self._theme_connected_labels.append(label)
         return label
 
     def _on_theme_changed(self):
         """Update all event labels when the theme switches."""
         color = COLOR_THEME[configGui.theme.value]['text']
-        for label in self._theme_connected_labels:
+        for label in self.qLabels:
             label.setStyleSheet(f'color: {color};')
+        if hasattr(self, 'label_3'):
+            self.label_3.setStyleSheet(f'color: {color};')
 
     def _read_config(self):
         with open(self.config.config_dir + '/event.json', 'r', encoding='utf-8') as f:
@@ -186,7 +185,6 @@ class Layout(QWidget):
         temp = deepcopy(self._event_config)
         # clear original components
         self.qLabels, self.times, self.check_boxes = [], [], []
-        self._theme_connected_labels = []  # discard refs to old destroyed labels
         self.tableView.clearContents()
         self.vBox.removeWidget(self.tableView)
         self.tableView.deleteLater()

--- a/gui/components/expand/featureSwitch.py
+++ b/gui/components/expand/featureSwitch.py
@@ -10,6 +10,7 @@ from qfluentwidgets import CheckBox, TableWidget, PushButton, ComboBox, CaptionL
     SubtitleLabel
 
 from gui.components.expand.expandTemplate import TemplateLayoutV2
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.customized_ui import ClickFocusLineEdit
 from gui.util.translator import baasTranslator as bt
 
@@ -77,6 +78,8 @@ class Layout(QWidget):
         assert self._event_config is not None
         self._crt_order_config = self._event_config
         self.config.get_signal('update_signal').connect(self._refresh_time)
+        self._theme_connected_labels = []
+        configGui.themeChanged.connect(self._on_theme_changed)
 
         self.boxes, self.qLabels, self.times, self.check_boxes, self.config_buttons = [], [], [], [], []
         self._init_components(self._event_config)
@@ -94,7 +97,7 @@ class Layout(QWidget):
         self.op_2.clicked.connect(self._refresh)
 
         self.option_layout.addStretch(1)
-        self.label_3 = CaptionLabel(self.tr('排序方式：'), self)
+        self.label_3 = self._make_event_label(self.tr('排序方式：'))
         self.op_3 = ComboBox(self)
         self.op_3.addItems([self.tr('默认排序'), self.tr('按下次执行时间排序')])
 
@@ -133,7 +136,7 @@ class Layout(QWidget):
             cbx_layout.addWidget(t_cbx, 1, Qt.AlignCenter)
             cbx_layout.setContentsMargins(30, 0, 0, 0)
             cbx_wrapper.setLayout(cbx_layout)
-            t_ccs = CaptionLabel(bt.tr('ConfigTranslation', self.labels[i]), self)
+            t_ccs = self._make_event_label(bt.tr('ConfigTranslation', self.labels[i]))
             t_ncs = ClickFocusLineEdit(self)
             t_ncs.setClearButtonEnabled(True)
             t_ncs.setText(str(datetime.fromtimestamp(self.next_ticks[i])).split('.')[0])
@@ -153,6 +156,21 @@ class Layout(QWidget):
             cfbs_wrapper.setLayout(cfbs_layout)
             self.config_buttons.append(cfbs_wrapper)
 
+    def _make_event_label(self, text: str) -> CaptionLabel:
+        """Create a CaptionLabel with correct text color for the current theme,
+        and register it for automatic updates when the theme changes."""
+        label = CaptionLabel(text)
+        color = COLOR_THEME[configGui.theme.value]['text']
+        label.setStyleSheet(f'color: {color};')
+        self._theme_connected_labels.append(label)
+        return label
+
+    def _on_theme_changed(self):
+        """Update all event labels when the theme switches."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_connected_labels:
+            label.setStyleSheet(f'color: {color};')
+
     def _read_config(self):
         with open(self.config.config_dir + '/event.json', 'r', encoding='utf-8') as f:
             s = f.read()
@@ -168,6 +186,7 @@ class Layout(QWidget):
         temp = deepcopy(self._event_config)
         # clear original components
         self.qLabels, self.times, self.check_boxes = [], [], []
+        self._theme_connected_labels = []  # discard refs to old destroyed labels
         self.tableView.clearContents()
         self.vBox.removeWidget(self.tableView)
         self.tableView.deleteLater()
@@ -188,7 +207,8 @@ class Layout(QWidget):
         self._crt_order_config = temp
         # Add components to table
         for ind, unit in enumerate(temp):
-            t_ccs = CaptionLabel(bt.tr('ConfigTranslation', unit['event_name']))
+            # t_ccs = CaptionLabel(bt.tr('ConfigTranslation', unit['event_name']))
+            t_ccs = self._make_event_label(bt.tr('ConfigTranslation', unit['event_name']))
             self.tableView.setCellWidget(ind, 0, t_ccs)
             self.qLabels.append(t_ccs)
 

--- a/gui/fragments/home.py
+++ b/gui/fragments/home.py
@@ -19,6 +19,7 @@ from qfluentwidgets import (
 )
 
 from core.notification import notify
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.customized_ui import AssetsWidget, FuncLabel
 from gui.util.translator import baasTranslator as bt
 from window import Window
@@ -59,6 +60,10 @@ class HomeFragment(QFrame):
         self.infoLayout.addWidget(self.label, 0, Qt.AlignLeft)
         self.infoLayout.addStretch(1)
         self.infoLayout.addWidget(self.info, 0, Qt.AlignRight)
+
+        self._theme_labels = [self.label, self.info]
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
         self.banner = FuncLabel(self)
         self.banner.setFixedHeight(200)
@@ -160,6 +165,12 @@ class HomeFragment(QFrame):
         self.setObjectName(f"{self.object_name}.HomeFragment")
         if self.config.get('autostart'):
             self.startup_card.button.click()
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by QFrame not propagating theme palette."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_labels:
+            label.setStyleSheet(f'color: {color};')
 
     @pyqtSlot(int, str)
     def on_log_received(self, level: int, message: str) -> None:

--- a/gui/fragments/process.py
+++ b/gui/fragments/process.py
@@ -9,6 +9,7 @@ from qfluentwidgets import (ScrollArea, TitleLabel, SubtitleLabel, ListWidget, S
                             ToolTipPosition, ToolTipFilter)
 
 from gui.components import expand
+from gui.util.config_gui import configGui, COLOR_THEME
 from gui.util.style_sheet import StyleSheet
 from gui.util.translator import baasTranslator as bt
 
@@ -27,9 +28,9 @@ class ProcessFragment(ScrollArea):
         self.titleLineLayout = QHBoxLayout()
         _scheduler_selector = config.get('new_event_enable_state')
         _scheduler_selector_layout = QHBoxLayout()
-        _scheduler_selector_label = SubtitleLabel(self.tr("调度状态"), self)
-        _scheduler_selector_label.setToolTip(self.tr("当BAAS新增调度任务时的启用状态"))
-        _scheduler_selector_label.installEventFilter(ToolTipFilter(_scheduler_selector_label, position=ToolTipPosition.TOP))
+        self._scheduler_selector_label = SubtitleLabel(self.tr("调度状态"), self)
+        self._scheduler_selector_label.setToolTip(self.tr("当BAAS新增调度任务时的启用状态"))
+        self._scheduler_selector_label.installEventFilter(ToolTipFilter(self._scheduler_selector_label, position=ToolTipPosition.TOP))
 
         __dict__for_scheduler_selector = {
             '开': 'on',
@@ -47,7 +48,7 @@ class ProcessFragment(ScrollArea):
         self.scheduler_selector.setCurrentText(bt.tr('ConfigTranslation', _raw_scheduler_selector))
         self.scheduler_selector.currentTextChanged.connect(
             lambda x: config.set('new_event_enable_state', __dict__for_scheduler_selector[bt.undo(x)]))
-        _scheduler_selector_layout.addWidget(_scheduler_selector_label)
+        _scheduler_selector_layout.addWidget(self._scheduler_selector_label)
         _scheduler_selector_layout.addWidget(self.scheduler_selector)
 
         self.titleLineLayout.addWidget(self.settingLabel, 1, Qt.AlignLeft)
@@ -74,6 +75,12 @@ class ProcessFragment(ScrollArea):
 
         self.vBox2.addWidget(self.label_queuing)
         self.vBox2.addWidget(self.listWidget)
+
+        self._theme_labels = [
+            self.settingLabel, self._scheduler_selector_label,
+            self.label_running, self.label_queuing
+        ]
+        configGui.themeChanged.connect(self._apply_label_colors)
 
         self.HBoxLayout.addLayout(self.vBox1)
         self.HBoxLayout.addLayout(self.vBox2)
@@ -135,3 +142,10 @@ class ProcessFragment(ScrollArea):
         self.listWidget.setObjectName('listWidget')
         StyleSheet.PROCESS.apply(self.on_status)
         StyleSheet.PROCESS.apply(self.listWidget)
+        self._apply_label_colors()
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        for label in self._theme_labels:
+            label.setStyleSheet(f'color: {color};')

--- a/gui/fragments/process.py
+++ b/gui/fragments/process.py
@@ -3,7 +3,7 @@ import time
 from hashlib import md5
 from random import random
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout
 from qfluentwidgets import (ScrollArea, TitleLabel, SubtitleLabel, ListWidget, StrongBodyLabel, ComboBox,
                             ToolTipPosition, ToolTipFilter)
@@ -18,6 +18,11 @@ DISPLAY_CONFIG_PATH = './config/display.json'
 
 
 class ProcessFragment(ScrollArea):
+    # Emitted from the background refresh thread; widget updates happen on
+    # the GUI thread via a queued connection (Qt forbids touching widgets
+    # from any other thread and crashes randomly when it happens).
+    status_signal = pyqtSignal(str, list)
+
     def __init__(self, parent, config):
         super().__init__(parent=parent)
         self.processWidget = QWidget()
@@ -97,6 +102,7 @@ class ProcessFragment(ScrollArea):
 
         self.baas_thread = None
         self.config = config
+        self.status_signal.connect(self._update_status_widgets)
         t_daemon = threading.Thread(target=self.refresh_status, daemon=True)
         t_daemon.start()
         self.__initLayout()
@@ -112,17 +118,22 @@ class ProcessFragment(ScrollArea):
                 crt_task = crt_task if crt_task else self.tr("暂无正在执行的任务")
                 task_list = [bt.tr('ConfigTranslation', task) for task in task_list] if task_list else [
                     self.tr("暂无队列中的任务")]
-                self.on_status.setText(bt.tr('ConfigTranslation', crt_task))
-
-                self.listWidget.clear()
-                self.listWidget.addItems(task_list)
             else:
-                self.on_status.setText(self.tr("暂无正在执行的任务"))
-                self.listWidget.clear()
-                self.listWidget.addItems([self.tr("暂无队列中的任务")])
+                crt_task = self.tr("暂无正在执行的任务")
+                task_list = [self.tr("暂无队列中的任务")]
                 main_thread = self.config.get_main_thread()
                 self.baas_thread = main_thread.get_baas_thread() if main_thread else None
+            self.status_signal.emit(crt_task, task_list)
             time.sleep(2)
+
+    def _update_status_widgets(self, crt_task: str, task_list: list):
+        """Update the scheduler status widgets on the GUI thread."""
+        if self.baas_thread is not None:
+            self.on_status.setText(bt.tr('ConfigTranslation', crt_task))
+        else:
+            self.on_status.setText(crt_task)
+        self.listWidget.clear()
+        self.listWidget.addItems(task_list)
 
     def __initLayout(self):
         # self.expandLayout.setSpacing(28)

--- a/gui/fragments/settings.py
+++ b/gui/fragments/settings.py
@@ -12,7 +12,7 @@ import window
 from gui.components import expand
 from gui.components.template_card import SimpleSettingCard
 from gui.util import notification
-from gui.util.config_gui import configGui, isWin11
+from gui.util.config_gui import configGui, isWin11, COLOR_THEME
 from gui.util.language import Language
 
 
@@ -206,6 +206,8 @@ class SettingsFragment(ScrollArea):
         self.expandLayout.addWidget(self.guiGroup)
 
         self.setWidget(self.scrollWidget)
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
     def __showRestartTooltip(self):
         """ show restart tooltip """
@@ -227,3 +229,8 @@ class SettingsFragment(ScrollArea):
         self.themeCard.optionChanged.connect(lambda ci: setTheme(configGui.get(ci)))
         self.themeColorCard.colorChanged.connect(lambda c: setThemeColor(c))
         self.micaCard.checkedChanged.connect(lambda x: configGui.micaEnableChanged.emit(x))
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        self.settingLabel.setStyleSheet(f'color: {color};')

--- a/gui/fragments/switch.py
+++ b/gui/fragments/switch.py
@@ -13,7 +13,7 @@ from qfluentwidgets import SettingCardGroup
 
 from gui.components import expand
 from gui.components.template_card import TemplateSettingCard, TemplateSettingCardForClick
-from gui.util.config_gui import configGui
+from gui.util.config_gui import configGui, COLOR_THEME
 
 lock = threading.Lock()
 
@@ -273,9 +273,16 @@ class SwitchFragment(ScrollArea):
         self.viewport().setStyleSheet("background-color: transparent;")
         self.expandLayout.addWidget(self.settingLabel)
         self.update_settings()
+        configGui.themeChanged.connect(self._apply_label_colors)
+        self._apply_label_colors()
 
     def __initWidget(self):
         """
         Sets the scrollable widget for the scroll area.
         """
         self.setWidget(self.scrollWidget)
+
+    def _apply_label_colors(self):
+        """Apply theme-correct text color to labels affected by the QScrollArea stylesheet cascade."""
+        color = COLOR_THEME[configGui.theme.value]['text']
+        self.settingLabel.setStyleSheet(f'color: {color};')

--- a/gui/qss/light/process.qss
+++ b/gui/qss/light/process.qss
@@ -2,6 +2,7 @@
     font-size: 18px;
     padding: 10px;
     font-weight: bold;
+    color: #333333;
     background-color: #e0f0e0;
     border-radius: 10px;
 }

--- a/gui/util/customized_ui.py
+++ b/gui/util/customized_ui.py
@@ -411,6 +411,7 @@ class AssetsWidget(QFrame):
                 font-size: %(line_height)dpx;
                 line-height: %(item_height)dpx;
                 border: none;
+                color: %(text_color)s;
             }
 
             QToolTip {
@@ -424,6 +425,7 @@ class AssetsWidget(QFrame):
         """ % {
             'background_color': COLOR_THEME[configGui.theme.value]['background'],
             'border_color': COLOR_THEME[configGui.theme.value]['border'],
+            'text_color': COLOR_THEME[configGui.theme.value]['text'],
             'line_height': (self.item_height - 10) // 2,
             'item_height': self.item_height
         })


### PR DESCRIPTION
Fixes #558

---

## 问题
`ProcessFragment.refresh_status()` 在 daemon 线程里直接调用了 QWidget 的方法：

```python
self.on_status.setText(...)
self.listWidget.clear()
self.listWidget.addItems(...)
```

Qt 禁止在非 GUI 线程里操作 widget。这样做：
- 在大多数平台上抛 `RuntimeError: QObject::setText: Cannot send to a target object` / `QObject: Cannot create children for a parent that is in a different thread`
- 在 Windows 上偶尔直接 segfault 进程，没有任何 Python 异常可捕

实际触发路径：调度状态每 2 秒刷新一次（`time.sleep(2)`），一旦 `refresh_status` 恰好在 GUI 线程忙碌时跑，撞上 widget 操作就崩。

## 修复
数据走信号，widget 操作必须在 GUI 线程。

```python
status_signal = pyqtSignal(str, list)   # 类属性，跨实例/跨线程安全
...
self.status_signal.connect(self._update_status_widgets)
...
# 后台线程：
self.status_signal.emit(crt_task, task_list)
time.sleep(2)

# GUI 线程（跨线程连接自动走 Qt Queued Connection）：
def _update_status_widgets(self, crt_task: str, task_list: list):
    ...
    self.on_status.setText(...)
    self.listWidget.clear()
    self.listWidget.addItems(...)
```

- `pyqtSignal.emit()` 跨线程时自动用 `Qt.QueuedConnection`，slot 会在接收对象所属线程（即 GUI 线程）执行
- 顺手把 if/else 两个分支里重复的 `self.on_status.setText(...)` + `self.listWidget.clear() + addItems(...)` 收口到 `_update_status_widgets` 里，避免再次有人不小心在 `refresh_status` 里漏掉一处

## 依赖
基于 PR #1（`fix/dark-mode-event-text-color`）。需要先合 PR #1，本 PR 才能合到 master。


---

## Note: base is `master`

This PR is currently based on `master`, so the diff includes the dark-mode
fixes that PR #554 already covers. Correct merge flow:

1. Merge PR #554 (dark mode) first.
2. Either retarget this PR to `master` and rebase, or merge this PR into
   the head branch of PR #554 and then merge PR #554.
3. After that the diff collapses to just the threading fix itself.

I initially tried to use `fix/dark-mode-event-text-color` as the base,
but that branch only exists on the fork (`2003Tim`), not on upstream.
The cleanest fix is for the maintainer to retarget this PR after PR #554
merges (one click in the GitHub UI).
