### PR TITLE
fix(gui): correct shop colors in dark mode

### DIFF
--- a/develop_tools/test/test_shop_responsive_layout.py
+++ b/develop_tools/test/test_shop_responsive_layout.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPalette
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import (
     QApplication,
@@ -22,9 +23,10 @@ from PyQt5.QtWidgets import (
     QStyleOptionButton,
     QWidget,
 )
-from qfluentwidgets import ScrollArea
+from qfluentwidgets import ScrollArea, Theme, setTheme
 
 from gui.components.expand import arenaShopPriority, shopPriority
+from gui.components.shop_goods import ShopGoodCard, ShopRefreshBox
 from gui.util.customized_ui import DialogSettingBox
 
 
@@ -65,12 +67,43 @@ class ShopResponsiveLayoutTest(unittest.TestCase):
         self.widgets = []
 
     def tearDown(self):
+        setTheme(Theme.LIGHT)
         shopPriority.bt.tr = self._shop_tr
         arenaShopPriority.bt.tr = self._arena_tr
         for widget in reversed(self.widgets):
             widget.close()
             widget.deleteLater()
         self.app.processEvents()
+
+    def test_goods_card_labels_follow_dark_and_light_theme_text_colors(self):
+        card = self._show(ShopGoodCard("Item name", "125000 credits"), 280, 80)
+
+        setTheme(Theme.DARK)
+        self.app.processEvents()
+        for label in (card.name_label, card.price_label):
+            self.assertGreater(
+                label.palette().color(QPalette.WindowText).lightness(),
+                180,
+            )
+
+        setTheme(Theme.LIGHT)
+        self.app.processEvents()
+        for label in (card.name_label, card.price_label):
+            self.assertLess(
+                label.palette().color(QPalette.WindowText).lightness(),
+                80,
+            )
+
+    def test_refresh_box_border_follows_dark_and_light_theme(self):
+        refresh_box = self._show(ShopRefreshBox(), 280, 60)
+
+        setTheme(Theme.DARK)
+        self.app.processEvents()
+        self.assertIn("rgba(255, 255, 255, 55)", refresh_box.styleSheet())
+
+        setTheme(Theme.LIGHT)
+        self.app.processEvents()
+        self.assertIn("rgba(0, 0, 0, 55)", refresh_box.styleSheet())
 
     def _show(self, widget, width, height=900):
         self.widgets.append(widget)

--- a/gui/components/expand/arenaShopPriority.py
+++ b/gui/components/expand/arenaShopPriority.py
@@ -1,10 +1,10 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIntValidator
-from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout, QVBoxLayout, QSizePolicy, QFrame
+from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout, QVBoxLayout, QSizePolicy
 from qfluentwidgets import LineEdit
 
 from gui.util.translator import baasTranslator as bt
-from gui.components.shop_goods import ShopGoodCard, ShopGoodsGrid
+from gui.components.shop_goods import ShopGoodCard, ShopGoodsGrid, ShopRefreshBox
 
 
 _PAD_Y = 16
@@ -29,15 +29,7 @@ class Layout(QWidget):
         root.setSpacing(8)
         root.setAlignment(Qt.AlignTop)
 
-        refresh_box = QFrame(self)
-        refresh_box.setObjectName('shopRefreshBox')
-        refresh_box.setStyleSheet(
-            'QFrame#shopRefreshBox {'
-            '  border: 1px solid rgba(0, 0, 0, 55);'
-            '  border-radius: 6px;'
-            '  background: rgba(0, 0, 0, 4);'
-            '}'
-        )
+        refresh_box = ShopRefreshBox(self)
         refresh_row = QHBoxLayout(refresh_box)
         refresh_row.setContentsMargins(10, 6, 10, 6)
         refresh_row.setSpacing(8)

--- a/gui/components/expand/shopPriority.py
+++ b/gui/components/expand/shopPriority.py
@@ -1,10 +1,10 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIntValidator
-from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout, QVBoxLayout, QSizePolicy, QFrame
+from PyQt5.QtWidgets import QWidget, QLabel, QHBoxLayout, QVBoxLayout, QSizePolicy
 from qfluentwidgets import LineEdit
 
 from gui.util.translator import baasTranslator as bt
-from gui.components.shop_goods import ShopGoodCard, ShopGoodsGrid
+from gui.components.shop_goods import ShopGoodCard, ShopGoodsGrid, ShopRefreshBox
 
 
 _PAD_Y = 16
@@ -29,15 +29,7 @@ class Layout(QWidget):
         root.setSpacing(8)
         root.setAlignment(Qt.AlignTop)
 
-        refresh_box = QFrame(self)
-        refresh_box.setObjectName('shopRefreshBox')
-        refresh_box.setStyleSheet(
-            'QFrame#shopRefreshBox {'
-            '  border: 1px solid rgba(0, 0, 0, 55);'
-            '  border-radius: 6px;'
-            '  background: rgba(0, 0, 0, 4);'
-            '}'
-        )
+        refresh_box = ShopRefreshBox(self)
         refresh_row = QHBoxLayout(refresh_box)
         refresh_row.setContentsMargins(10, 6, 10, 6)
         refresh_row.setSpacing(8)

--- a/gui/components/shop_goods.py
+++ b/gui/components/shop_goods.py
@@ -4,12 +4,11 @@ from PyQt5.QtWidgets import (
     QGridLayout,
     QFrame,
     QHBoxLayout,
-    QLabel,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import CheckBox
+from qfluentwidgets import BodyLabel, CheckBox, isDarkTheme, qconfig
 
 
 SHOP_PREFERRED_WIDTH = 800
@@ -21,6 +20,26 @@ SHOP_DIALOG_VERTICAL_RESERVE = 180
 GRID_MIN_COLUMN_WIDTH = 220
 GRID_HORIZONTAL_SPACING = 8
 GRID_VERTICAL_SPACING = 8
+
+
+class ShopRefreshBox(QFrame):
+    """Full-width refresh control container that follows the active theme."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName('shopRefreshBox')
+        qconfig.themeChanged.connect(self._apply_theme)
+        self._apply_theme()
+
+    def _apply_theme(self, *_):
+        base = 255 if isDarkTheme() else 0
+        self.setStyleSheet(
+            'QFrame#shopRefreshBox {'
+            f'  border: 1px solid rgba({base}, {base}, {base}, 55);'
+            '  border-radius: 6px;'
+            f'  background-color: rgba({base}, {base}, {base}, 4);'
+            '}'
+        )
 
 
 class ShopGoodCard(QFrame):
@@ -44,12 +63,12 @@ class ShopGoodCard(QFrame):
         self.check_box.setChecked(checked)
         self.check_box.setLayoutDirection(Qt.RightToLeft)
 
-        self.name_label = QLabel(name, self)
+        self.name_label = BodyLabel(name, self)
         self.name_label.setWordWrap(True)
         self.name_label.setAttribute(Qt.WA_TransparentForMouseEvents)
         self.name_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
-        self.price_label = QLabel(price, self)
+        self.price_label = BodyLabel(price, self)
         self.price_label.setWordWrap(True)
         self.price_label.setAttribute(Qt.WA_TransparentForMouseEvents)
         self.price_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)


### PR DESCRIPTION
## Summary

- make shop item names and prices follow the active Fluent theme
- share a theme-aware refresh-count container between the tactical challenge and arena shops
- update the refresh container border and background when the theme changes at runtime
- add dark/light theme regression coverage for shop cards and the refresh container

This is a visual follow-up to #545.

## Testing

- `python -m unittest develop_tools.test.test_shop_responsive_layout` (9 tests passed)
- `python -m compileall -q gui/components/shop_goods.py gui/components/expand/shopPriority.py gui/components/expand/arenaShopPriority.py`
- `git diff --check`