### PR TITLE
Fix pyautogui swipe

### DIFF
--- a/core/device/control/pyautogui.py
+++ b/core/device/control/pyautogui.py
@@ -25,14 +25,14 @@ class PyautoguiControl:
         x2, y2 = self._convert_screen_p_to_window_p(x2, y2)
         
         pyautogui.moveTo(x1, y1)
-        pyautogui.mouseDown(button='left')
+        pyautogui.mouseDown(button=pyautogui.PRIMARY)
         time.sleep(0.1)
         
         drag_duration = duration if duration is not None else 0.5
         pyautogui.moveTo(x2, y2, duration=drag_duration)
         
         time.sleep(0.1)
-        pyautogui.mouseUp(button='left')
+        pyautogui.mouseUp(button=pyautogui.PRIMARY)
 
     def scroll(self, x, y, clicks):
         self._ensure_window()

--- a/core/device/control/pyautogui.py
+++ b/core/device/control/pyautogui.py
@@ -23,8 +23,16 @@ class PyautoguiControl:
         self._ensure_window()
         x1, y1 = self._convert_screen_p_to_window_p(x1, y1)
         x2, y2 = self._convert_screen_p_to_window_p(x2, y2)
+        
         pyautogui.moveTo(x1, y1)
-        pyautogui.dragTo(x2, y2, duration=duration)
+        pyautogui.mouseDown(button='left')
+        time.sleep(0.1)
+        
+        drag_duration = duration if duration is not None else 0.5
+        pyautogui.moveTo(x2, y2, duration=drag_duration)
+        
+        time.sleep(0.1)
+        pyautogui.mouseUp(button='left')
 
     def scroll(self, x, y, clicks):
         self._ensure_window()

--- a/module/explore_tasks/task_utils.py
+++ b/module/explore_tasks/task_utils.py
@@ -449,7 +449,7 @@ def employ_units(self, choose_team_method: str, task_data: dict, team_config: di
     for command, info in task_data["start"]:
         if command == "swipe":
             time.sleep(1)
-            self.u2_swipe(info[0], info[1], info[2], info[3], duration=info[4], post_sleep_time=1)
+            self.swipe(info[0], info[1], info[2], info[3], duration=info[4], post_sleep_time=1)
         else:
             # employ command
             column = employ_pos[employed][0]


### PR DESCRIPTION
**Description**
Fixed a critical bug where the script would crash due to calling `u2_swipe` when using the `pyautogui` control method (e.g., PC/Steam clients), alongside fixing swipe recognition issues.

1. Replaced hardcoded `u2_swipe` with the generic `swipe` function in `task_utils.py` to resolve the `AttributeError` crash on non-Android setups.
2. Added `time.sleep(0.1)` hold delays to `pyautogui.py`'s mouse events. This ensures the Unity engine properly recognizes the physical drag action on grid maps.

---

**中文说明**
修复了在 PC 端使用 pyautogui 驱动时，因底层硬编码调用 `u2_swipe` 导致任务直接报错崩溃的 Bug。

1. **业务层**：去除了 `task_utils` 里的 `u2_swipe` 硬编码，改用通用 `swipe` 接口。彻底解决非安卓环境下实例未初始化导致的 `AttributeError` 崩溃问题。
2. **驱动层**：重写了 `pyautogui.dragTo`，将其拆解为带 0.1 秒延迟的按下、移动和松开动作。解决了 PC 端 Unity 引擎无法正确识别瞬间地图拖拽指令的问题。

---

**Screenshots & Logs**

<img width="1280" height="759" alt="errorscreeshot" src="https://github.com/user-attachments/assets/6caa69b2-a8d7-4d78-8237-462432bc2687" />

*The red arrow indicates the second deployment location, which requires swiping the map to reach.*

[normal_18_3_errorlogs.txt](https://github.com/user-attachments/files/31651925/normal_18_3_errorlogs.txt)

---

*Note: This is my first time contributing to this project. While I have thoroughly tested these changes locally, please let me know if there is a more idiomatic way to handle this within the project's overall architecture. I'm open to any feedback or changes!*

*(注：这是我首次为本项目提交 PR。虽然已经在本地完成了充分的测试，但如果这种修改方式不完全符合项目的架构规范，请随时指出，我非常乐意配合调整！)*