### PR TITLE
fix: 补齐新增日程区域的奖励优先级配置

### DIFF
--- a/core/config/default_config.py
+++ b/core/config/default_config.py
@@ -428,6 +428,7 @@ DEFAULT_CONFIG = """
         ["primary","normal","advanced","superior"],
         ["primary","normal","advanced","superior"],
         ["primary","normal","advanced","superior"],
+        ["primary","normal","advanced","superior"],
         ["primary","normal","advanced","superior"]
     ],
     "purchase_lesson_ticket_times": "0",

--- a/module/lesson.py
+++ b/module/lesson.py
@@ -426,7 +426,8 @@ def choose_lesson(self, res, region):
         return lo
     else:
         tier = ["superior", "advanced", "normal", "primary"]
-        pri = self.config.lesson_each_region_object_priority[region]
+        priorities = self.config.lesson_each_region_object_priority
+        pri = priorities[region] if region < len(priorities) else tier
         if pri == []:
             for i in range(8, -1, -1):  # choose the last available which gives higher tier reward
                 if res[0][i] == "available":

--- a/window.py
+++ b/window.py
@@ -55,6 +55,9 @@ def update_config_reserve_old(config_old, config_new):  # 保留旧配置原有�
     for key in config_new:
         if key not in config_old:
             config_old[key] = config_new[key]
+    key = "lesson_each_region_object_priority"
+    if len(config_old.get(key, [])) < len(config_new.get(key, [])):
+        config_old[key].extend(config_new[key][len(config_old[key]):])
     dels = []
     for key in config_old:
         if key not in config_new:


### PR DESCRIPTION
## 问题

国服日程区域在提交 `7e74553ee` 中新增了“春叶原”，区域数量由 10 增至 11，但 `lesson_each_region_object_priority` 的默认数组仍只有 10 项。

旧账号启动时，现有配置更新逻辑只补充缺失的顶层键，不补齐已有列表的新增元素。因此界面虽然可以根据 11 个区域临时渲染默认勾选，配置文件仍保持 10 项。执行春叶原时，`choose_lesson()` 使用区域索引 10 读取该数组，最终触发：

```text
IndexError: list index out of range
```

该异常会中止当前账号的全部活动并要求人工接管。

## 修改

- 将默认 `lesson_each_region_object_priority` 补齐为 11 项，为春叶原加入 `primary / normal / advanced / superior` 默认优先级。
- 在旧配置迁移时，仅针对该字段按默认配置追加缺少的尾部元素，保留用户已有区域的设置。
- 在课程选择逻辑增加轻量越界兜底；未来配置长度再次不一致时不会停止全部活动。

## 影响范围

仅影响日程区域奖励优先级的默认值、旧配置补齐和异常兜底。不会改变已有 10 个区域的用户设置，也不会修改日程次数、好感度优先或邀请学生逻辑。

## 验证

- 基于上游最新 `master`（`5be8600f7`）创建独立分支。
- 默认配置可解析，优先级数组长度为 11。
- Python 编译检查与 `git diff --check` 通过。
- 按要求未加入回归测试文件。
